### PR TITLE
averez-installation-mac: installation fixes on a Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ go_get_deps:
 	$(GOGETTER) github.com/jvehent/cljs
 	$(GOGETTER) bitbucket.org/kardianos/osext
 	$(GOGETTER) bitbucket.org/kardianos/service
-	
+	$(GOGETTER) github.com/VividCortex/godaemon
+	$(GOGETTER) github.com/mozilla/mig/src/mig/modules/filechecker
 
 install: gpgme mig-agent mig-scheduler
 	$(INSTALL) -D -m 0755 $(BINDIR)/mig-agent $(DESTDIR)$(PREFIX)/sbin/mig-agent

--- a/src/mig/pgp/sign/sign.go
+++ b/src/mig/pgp/sign/sign.go
@@ -43,7 +43,7 @@ import (
 
 /*
 #cgo CFLAGS: -I.
-#cgo LDFLAGS: -lgpgme libmig_gpgme.a
+#cgo LDFLAGS: -lgpgme -lgpg-error libmig_gpgme.a
 #include <libmig_gpgme.h>
 */
 import "C"


### PR DESCRIPTION
- -lgpg-error: otherwise some gpg error symbols not found by clang
- fix dependencies
