### PR TITLE
Allow building doc from top level dir, add cheatsheet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,9 @@ rpm-api: mig-api
 	fpm -C tmp -n mig-api --license GPL --vendor mozilla --description "Mozilla InvestiGator API" \
 		-m "Mozilla OpSec" --url http://mig.mozilla.org --architecture $(FPMARCH) -v $(BUILDREV) -s dir -t rpm .
 
+doc:
+	make -C doc doc
+
 test: mig-agent
 	$(BINDIR)/mig-agent-latest -m=file '{"searches": {"shouldmatch": {"names": ["^root"],"sizes": ["<10m"],"options": {"matchall": true},"paths": ["/etc/passwd"]},"shouldnotmatch": {"options": {"maxdepth": 1},"paths": ["/tmp"],"contents": ["should not match"]}}}'
 
@@ -256,4 +259,4 @@ clean: clean-agent
 	rm -rf tmp
 	find src/ -maxdepth 1 -mindepth 1 ! -name mig -exec rm -rf {} \;
 
-.PHONY: clean clean-all clean-agent doc go_get_deps_into_system mig-agent-386 mig-agent-amd64 agent-install-script agent-cron
+.PHONY: clean clean-agent doc go_get_deps_into_system mig-agent-386 mig-agent-amd64 agent-install-script agent-cron

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,10 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# # License, v. 2.0. If a copy of the MPL was not distributed with this
+# # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+RST2HTML	:= rst2html5
+
 doc:
 	for doc in $$(ls *.rst); do \
-		rst2html5 --stylesheet=docstyle.css "$$doc" > "$$doc.html"; \
+		$(RST2HTML) --stylesheet=docstyle.css "$$doc" > "$$doc.html"; \
 	done
 	for modname in $(ls ../src/mig/modules/); do \
 		if [ -r "../src/mig/modules/$modname/doc.rst" ]; then \
-			rst2html5 --stylesheet=docstyle.css "../src/mig/modules/$modname/doc.rst" > "module_$modname.html"; \
+			$(RST2HTML) --stylesheet=docstyle.css "../src/mig/modules/$modname/doc.rst" > "module_$modname.html"; \
 		fi; \
 	done
 	dot -Tsvg -o .files/action_command_flow.svg .files/action_command_flow.dot

--- a/doc/cheatsheet.rst
+++ b/doc/cheatsheet.rst
@@ -11,29 +11,25 @@ This is a list of common operations you may want to run with MIG.
 File/Filechecker module operations
 ==================================
 
-Find if files in /etc/cron.d contain "mysql://" on hosts "*buildbot*"
-----------------------------------------------------------------------
+- Find if files in /etc/cron.d contain "mysql://" on hosts "*buildbot*"
 
 .. code:: bash
 
     mig file -t "os='linux' AND name like '%buildbot%'" -path /etc/cron.d/ -content "mysql://"
 
-Find if file /etc/passwd has been modified in the past 2 days
--------------------------------------------------------------
+- Find if file /etc/passwd has been modified in the past 2 days
 
 .. code:: bash
 
     mig file -t "os='linux'" -path /etc/passwd -mtime <2d
 
-Find endpoints with high uptime
--------------------------------
+- Find endpoints with high uptime
 
 .. code:: bash
 
     mig file -t "os='linux' OR os='darwin'" -path /proc/uptime -content "^[5-9]{1}[0-9]{7,}\\."
 
-Find endpoints running process "/sbin/auditd"
----------------------------------------------
+- Find endpoints running process "/sbin/auditd"
 
 .. code:: bash
 

--- a/doc/cheatsheet.rst
+++ b/doc/cheatsheet.rst
@@ -1,0 +1,40 @@
+================================
+Mozilla InvestiGator Cheat Sheet
+================================
+:Author: Guillaume Destuynder <kang@mozilla.com>
+
+.. sectnum::
+.. contents:: Table of Contents
+
+This is a list of common operations you may want to run with MIG.
+
+File/Filechecker module operations
+==================================
+
+Find if files in /etc/cron.d contain "mysql://" on hosts "*buildbot*"
+----------------------------------------------------------------------
+
+.. code:: bash
+
+    mig file -t "os='linux' AND name like '%buildbot%'" -path /etc/cron.d/ -content "mysql://"
+
+Find if file /etc/passwd has been modified in the past 2 days
+-------------------------------------------------------------
+
+.. code:: bash
+
+    mig file -t "os='linux'" -path /etc/passwd -mtime <2d
+
+Find endpoints with high uptime
+-------------------------------
+
+.. code:: bash
+
+    mig file -t "os='linux' OR os='darwin'" -path /proc/uptime -content "^[5-9]{1}[0-9]{7,}\\."
+
+Find endpoints running process "/sbin/auditd"
+---------------------------------------------
+
+.. code:: bash
+
+    mig file -t "os='linux'" -path /proc/ -name cmdline -content "/sbin/auditd"

--- a/doc/cheatsheet.rst.html
+++ b/doc/cheatsheet.rst.html
@@ -223,42 +223,36 @@ a {
 <div class="contents topic" id="table-of-contents">
 <p class="topic-title first">Table of Contents</p>
 <ul class="auto-toc simple">
-<li><a class="reference internal" href="#file-filechecker-module-operations" id="id1">1&nbsp;&nbsp;&nbsp;File/Filechecker module operations</a><ul class="auto-toc">
-<li><a class="reference internal" href="#find-if-files-in-etc-cron-d-contain-mysql-on-hosts-buildbot" id="id2">1.1&nbsp;&nbsp;&nbsp;Find if files in /etc/cron.d contain &quot;mysql://&quot; on hosts &quot;<em>buildbot</em>&quot;</a></li>
-<li><a class="reference internal" href="#find-if-file-etc-passwd-has-been-modified-in-the-past-2-days" id="id3">1.2&nbsp;&nbsp;&nbsp;Find if file /etc/passwd has been modified in the past 2 days</a></li>
-<li><a class="reference internal" href="#find-endpoints-with-high-uptime" id="id4">1.3&nbsp;&nbsp;&nbsp;Find endpoints with high uptime</a></li>
-<li><a class="reference internal" href="#find-endpoints-running-process-sbin-auditd" id="id5">1.4&nbsp;&nbsp;&nbsp;Find endpoints running process &quot;/sbin/auditd&quot;</a></li>
-</ul>
-</li>
+<li><a class="reference internal" href="#file-filechecker-module-operations" id="id1">1&nbsp;&nbsp;&nbsp;File/Filechecker module operations</a></li>
 </ul>
 </div>
 <p>This is a list of common operations you may want to run with MIG.</p>
 <div class="section" id="file-filechecker-module-operations">
 <h1><a class="toc-backref" href="#id1">1&nbsp;&nbsp;&nbsp;File/Filechecker module operations</a></h1>
-<div class="section" id="find-if-files-in-etc-cron-d-contain-mysql-on-hosts-buildbot">
-<h2><a class="toc-backref" href="#id2">1.1&nbsp;&nbsp;&nbsp;Find if files in /etc/cron.d contain &quot;mysql://&quot; on hosts &quot;<em>buildbot</em>&quot;</a></h2>
+<ul class="simple">
+<li>Find if files in /etc/cron.d contain &quot;mysql://&quot; on hosts &quot;<em>buildbot</em>&quot;</li>
+</ul>
 <pre class="code bash literal-block">
 mig file -t <span class="literal string double">&quot;os='linux' AND name like '%buildbot%'&quot;</span> -path /etc/cron.d/ -content <span class="literal string double">&quot;mysql://&quot;</span>
 </pre>
-</div>
-<div class="section" id="find-if-file-etc-passwd-has-been-modified-in-the-past-2-days">
-<h2><a class="toc-backref" href="#id3">1.2&nbsp;&nbsp;&nbsp;Find if file /etc/passwd has been modified in the past 2 days</a></h2>
+<ul class="simple">
+<li>Find if file /etc/passwd has been modified in the past 2 days</li>
+</ul>
 <pre class="code bash literal-block">
 mig file -t <span class="literal string double">&quot;os='linux'&quot;</span> -path /etc/passwd -mtime &lt;2d
 </pre>
-</div>
-<div class="section" id="find-endpoints-with-high-uptime">
-<h2><a class="toc-backref" href="#id4">1.3&nbsp;&nbsp;&nbsp;Find endpoints with high uptime</a></h2>
+<ul class="simple">
+<li>Find endpoints with high uptime</li>
+</ul>
 <pre class="code bash literal-block">
 mig file -t <span class="literal string double">&quot;os='linux' OR os='darwin'&quot;</span> -path /proc/uptime -content <span class="literal string double">&quot;^[5-9]{1}[0-9]{7,}\\.&quot;</span>
 </pre>
-</div>
-<div class="section" id="find-endpoints-running-process-sbin-auditd">
-<h2><a class="toc-backref" href="#id5">1.4&nbsp;&nbsp;&nbsp;Find endpoints running process &quot;/sbin/auditd&quot;</a></h2>
+<ul class="simple">
+<li>Find endpoints running process &quot;/sbin/auditd&quot;</li>
+</ul>
 <pre class="code bash literal-block">
 mig file -t <span class="literal string double">&quot;os='linux'&quot;</span> -path /proc/ -name cmdline -content <span class="literal string double">&quot;/sbin/auditd&quot;</span>
 </pre>
-</div>
 </div>
 </div>
 </body>

--- a/doc/cheatsheet.rst.html
+++ b/doc/cheatsheet.rst.html
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="Docutils 0.12: http://docutils.sourceforge.net/" />
+<title>Mozilla InvestiGator Cheat Sheet</title>
+<meta name="author" content="Guillaume Destuynder &lt;kang&#64;mozilla.com&gt;" />
+<style type="text/css">
+
+body {
+  width: 95%;
+  max-width: 900px;
+  margin: 20px;
+  padding: 0;
+  background: #151515 url("../images/bkg.png") 0 0;
+  color: #eaeaea;
+  font: 16px;
+  line-height: 1.5;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
+}
+
+/* General & 'Reset' Stuff */
+
+.container {
+  width: 95%;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+section {
+  display: block;
+  margin: 0 0 20px 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  /*margin: 0 0 20px;*/
+  margin: 0;
+}
+
+li {
+  line-height: 1.4 ;
+}
+
+/* Header, <header>
+ *    header   - container
+ *       h1       - project name
+ *          h2       - project description
+ *          */
+
+header {
+  background: rgba(0, 0, 0, 0.1);
+  width: 100%;
+  border-bottom: 1px dashed #b5e853;
+  /*padding: 20px 0;
+ *   margin: 0 0 40px 0;*/
+  padding: 5px 0;
+  margin: 0 0 10px 0;
+}
+
+header h1 {
+  font-size: 30px;
+  line-height: 1.5;
+  margin: 0 0 0 -40px;
+  font-weight: bold;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
+  /*color: #b5e853;*/
+  color: #089d00;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1),
+               0 0 5px rgba(181, 232, 83, 0.1),
+               0 0 10px rgba(181, 232, 83, 0.1);
+  letter-spacing: -1px;
+  -webkit-font-smoothing: antialiased;
+}
+
+header h1:before {
+  content: "./ ";
+  font-size: 24px;
+}
+
+header h2 {
+  font-size: 18px;
+  font-weight: 300;
+  /*color: #666;*/
+  color: #ff7800;
+}
+
+/* Main Content
+ * */
+
+#main_content {
+  width: 100%;
+  -webkit-font-smoothing: antialiased;
+}
+section img {
+  max-width: 100%
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: normal;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
+  color: #b5e853;
+  letter-spacing: -0.03em;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1),
+               0 0 5px rgba(181, 232, 83, 0.1),
+               0 0 10px rgba(181, 232, 83, 0.1);
+}
+
+#main_content h1 {
+  font-size: 30px;
+}
+
+#main_content h2 {
+  font-size: 24px;
+}
+
+#main_content h3 {
+  font-size: 18px;
+}
+
+#main_content h4 {
+  font-size: 14px;
+}
+
+#main_content h5 {
+  font-size: 12px;
+  text-transform: uppercase;
+  margin: 0 0 5px 0;
+}
+
+#main_content h6 {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #999;
+  margin: 0 0 5px 0;
+}
+
+dt {
+  font-style: italic;
+  font-weight: bold;
+}
+/*
+ul li {
+  list-style: none;
+}
+*/
+/*
+ul li:before {
+  content: ">>";
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
+  font-size: 13px;
+  color: #b5e853;
+  margin-left: -37px;
+  margin-right: 21px;
+  line-height: 16px;
+}
+*/
+
+blockquote {
+  color: #aaa;
+  padding-left: 10px;
+  border-left: 1px dotted #666;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 10px;
+  font-size: 14px;
+  color: #b5e853;
+  border-radius: 2px;
+  -moz-border-radius: 2px;
+  -webkit-border-radius: 2px;
+  text-wrap: normal;
+  overflow: auto;
+  overflow-y: hidden;
+}
+
+table {
+  width: 100%;
+  margin: 0 0 20px 0;
+}
+
+th {
+  text-align: left;
+  border-bottom: 1px dashed #b5e853;
+  padding: 5px 10px;
+}
+
+td {
+  padding: 5px 10px;
+}
+
+hr {
+  height: 0;
+  border: 0;
+  border-bottom: 1px dashed #b5e853;
+  color: #b5e853;
+}
+/* Links
+ *    a, a:hover, a:visited
+ *    */
+
+a {
+  color: #63c0f5;
+  text-shadow: 0 0 5px rgba(104, 182, 255, 0.5);
+}
+
+
+</style>
+</head>
+<body>
+<div class="document" id="mozilla-investigator-cheat-sheet">
+<h1 class="title">Mozilla InvestiGator Cheat Sheet</h1>
+<table class="docinfo" frame="void" rules="none">
+<col class="docinfo-name" />
+<col class="docinfo-content" />
+<tbody valign="top">
+<tr><th class="docinfo-name">Author:</th>
+<td>Guillaume Destuynder &lt;<a class="reference external" href="mailto:kang&#64;mozilla.com">kang&#64;mozilla.com</a>&gt;</td></tr>
+</tbody>
+</table>
+<div class="contents topic" id="table-of-contents">
+<p class="topic-title first">Table of Contents</p>
+<ul class="auto-toc simple">
+<li><a class="reference internal" href="#file-filechecker-module-operations" id="id1">1&nbsp;&nbsp;&nbsp;File/Filechecker module operations</a><ul class="auto-toc">
+<li><a class="reference internal" href="#find-if-files-in-etc-cron-d-contain-mysql-on-hosts-buildbot" id="id2">1.1&nbsp;&nbsp;&nbsp;Find if files in /etc/cron.d contain &quot;mysql://&quot; on hosts &quot;<em>buildbot</em>&quot;</a></li>
+<li><a class="reference internal" href="#find-if-file-etc-passwd-has-been-modified-in-the-past-2-days" id="id3">1.2&nbsp;&nbsp;&nbsp;Find if file /etc/passwd has been modified in the past 2 days</a></li>
+<li><a class="reference internal" href="#find-endpoints-with-high-uptime" id="id4">1.3&nbsp;&nbsp;&nbsp;Find endpoints with high uptime</a></li>
+<li><a class="reference internal" href="#find-endpoints-running-process-sbin-auditd" id="id5">1.4&nbsp;&nbsp;&nbsp;Find endpoints running process &quot;/sbin/auditd&quot;</a></li>
+</ul>
+</li>
+</ul>
+</div>
+<p>This is a list of common operations you may want to run with MIG.</p>
+<div class="section" id="file-filechecker-module-operations">
+<h1><a class="toc-backref" href="#id1">1&nbsp;&nbsp;&nbsp;File/Filechecker module operations</a></h1>
+<div class="section" id="find-if-files-in-etc-cron-d-contain-mysql-on-hosts-buildbot">
+<h2><a class="toc-backref" href="#id2">1.1&nbsp;&nbsp;&nbsp;Find if files in /etc/cron.d contain &quot;mysql://&quot; on hosts &quot;<em>buildbot</em>&quot;</a></h2>
+<pre class="code bash literal-block">
+mig file -t <span class="literal string double">&quot;os='linux' AND name like '%buildbot%'&quot;</span> -path /etc/cron.d/ -content <span class="literal string double">&quot;mysql://&quot;</span>
+</pre>
+</div>
+<div class="section" id="find-if-file-etc-passwd-has-been-modified-in-the-past-2-days">
+<h2><a class="toc-backref" href="#id3">1.2&nbsp;&nbsp;&nbsp;Find if file /etc/passwd has been modified in the past 2 days</a></h2>
+<pre class="code bash literal-block">
+mig file -t <span class="literal string double">&quot;os='linux'&quot;</span> -path /etc/passwd -mtime &lt;2d
+</pre>
+</div>
+<div class="section" id="find-endpoints-with-high-uptime">
+<h2><a class="toc-backref" href="#id4">1.3&nbsp;&nbsp;&nbsp;Find endpoints with high uptime</a></h2>
+<pre class="code bash literal-block">
+mig file -t <span class="literal string double">&quot;os='linux' OR os='darwin'&quot;</span> -path /proc/uptime -content <span class="literal string double">&quot;^[5-9]{1}[0-9]{7,}\\.&quot;</span>
+</pre>
+</div>
+<div class="section" id="find-endpoints-running-process-sbin-auditd">
+<h2><a class="toc-backref" href="#id5">1.4&nbsp;&nbsp;&nbsp;Find endpoints running process &quot;/sbin/auditd&quot;</a></h2>
+<pre class="code bash literal-block">
+mig file -t <span class="literal string double">&quot;os='linux'&quot;</span> -path /proc/ -name cmdline -content <span class="literal string double">&quot;/sbin/auditd&quot;</span>
+</pre>
+</div>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Notes:
- I think rst2html is the default program name, I made it configurable and it defaults to the original value (rst2html5) but this probably only works on Fedora by default (?)
- I would think doc should be auto rebuilt / cleaned with make all/make clean - however, since the html output and others is dependent on a lot of things i didnt add that yet
- consequently my cheatsheet.rst.html document might be slightly different from yours and you might want to run make doc again :/
- /!\ :warning:  the file in doc/.files/createdb.sh seems to be missing from the tree so the doc building doesn't 100% succeeds. I suppose you have it locally @jvehent 