### PR TITLE
[major] Memory module, using Masche

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ MKDIR		:= mkdir
 INSTALL		:= install
 
 
-all: go_get_deps mig-agent mig-scheduler mig-api mig-cmd mig-console mig-action-generator mig-action-verifier worker-agent-intel worker-compliance-item
+all: go_get_deps test mig-agent mig-scheduler mig-api mig-cmd mig-console mig-action-generator mig-action-verifier worker-agent-intel worker-compliance-item
 
 mig-agent:
 	echo building mig-agent for $(OS)/$(ARCH)
@@ -311,11 +311,14 @@ worker-compliance-item:
 doc:
 	make -C doc doc
 
-test: mig-agent
-	$(BINDIR)/mig-agent-latest -m=file '{"searches": {"shouldmatch": {"names": ["^root"],"sizes": ["<10m"],"options": {"matchall": true},"paths": ["/etc/passwd"]},"shouldnotmatch": {"options": {"maxdepth": 1},"paths": ["/tmp"],"contents": ["should not match"]}}}'
+test: test-modules test-memory-modules
+	#$(GO) test mig/...
 
 test-modules:
 	$(GO) test mig/modules
+
+test-memory-modules:
+	$(GO) test mig/modules/memory
 
 clean-agent:
 	find bin/ -name mig-agent* -exec rm {} \;

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ go_get_common_deps:
 	$(GOGETTER) code.google.com/p/go.crypto/openpgp
 	$(GOGETTER) code.google.com/p/gcfg
 
-go_get_agent_deps: go_get_common_deps go_get_ping_deps
+go_get_agent_deps: go_get_common_deps go_get_ping_deps go_get_memory_deps
 	$(GOGETTER) code.google.com/p/go.crypto/sha3
 	$(GOGETTER) github.com/streadway/amqp
 	$(GOGETTER) github.com/kardianos/osext
@@ -113,6 +113,11 @@ go_get_ping_deps:
 	$(GOGETTER) golang.org/x/net/icmp
 	$(GOGETTER) golang.org/x/net/ipv4
 	$(GOGETTER) golang.org/x/net/ipv6
+
+go_get_memory_deps:
+	$(GOGETTER) github.com/mozilla/masche/process
+	$(GOGETTER) github.com/mozilla/masche/listlibs
+	$(GOGETTER) github.com/mozilla/masche/memsearch
 
 go_get_platform_deps: go_get_common_deps
 	$(GOGETTER) github.com/streadway/amqp

--- a/conf/available_modules.go
+++ b/conf/available_modules.go
@@ -8,9 +8,10 @@ package main
 import (
 	_ "mig/modules/agentdestroy"
 	_ "mig/modules/file"
+	_ "mig/modules/memory"
 	_ "mig/modules/netstat"
-	_ "mig/modules/timedrift"
 	_ "mig/modules/ping"
+	_ "mig/modules/timedrift"
 	//_ "mig/modules/upgrade"
 	//_ "mig/modules/example"
 )

--- a/src/mig/modules/memory/doc.rst
+++ b/src/mig/modules/memory/doc.rst
@@ -1,0 +1,139 @@
+===================================
+Mozilla InvestiGator: Memory module
+===================================
+:Author: Julien Vehent <jvehent@mozilla.com>
+
+.. sectnum::
+.. contents:: Table of Contents
+
+The memory module (MM) allows an investigator to inspect the content of the
+memory of running processes without impacting the stability of a system. MM
+implements the `Masche <https://github.com/mozilla/masche>`_ cross-platform
+memory scanning library.
+
+Usage
+-----
+
+MM implements searches that are defined by a search label. A search can have a
+number of search parameters and options, defined below. There is no maximum
+number of searches that can be performed by a single invocation of MM. The
+module optimize searches to only scan the memory of each process once, and for
+each buffer scanned, runs all needed checks on it.
+
+MM can filter processes on their name or their linked libraries. A standard way
+to use the module is to set the `MatchAll` option to `true` and specify a name
+and a content or byte string to search for. MM will first filter the processes
+that match the name, a cheap check to perform, and because `MatchAll` is true,
+will only peek inside the memory of selected processes.
+
+Without `MatchAll`, all checks are ran on all processes, which can be very
+costly on a system that has a large memory usage.
+
+In JSON format, searches are defined as a json object where each search has a
+label (key) and search parameters (value).
+
+A search label is a string between 1 and 64 characters, composed of letter
+[a-zA-z], numbers [0-9], underscore [_] or dashes [-].
+
+.. code:: json
+
+	{
+		"searches": {
+			"somesearchlabel": {
+				"names": [
+					"firefox"
+				],
+				"contents": [
+					"some bogus content"
+				]
+			},
+			"another_search": {
+				"libraries": [
+					"libssl"
+				],
+				"bytes": [
+					"afd37df8b18462"
+				],
+				"options": {
+					"matchall": true,
+					"maxlength": 50000
+				}
+			}
+        }
+    }
+
+Filters
+~~~~~~~
+Search filters can be used to locate a process on its name, libraries or
+content. Filters can be applied in two ways: either `matchall` is set and all
+filters must match on a given process to include it in the results, or `matchall`
+is not set and filters are treated individually.
+
+Note: all regular expressions used in search filters use the regexp syntax
+provided by the Go language, which is very similar to Posix. A full description
+of the syntax is available at http://golang.org/pkg/regexp/syntax/.
+
+* **names**: an array of regular expressions that are applied to the full
+  executable path of a process
+
+* **libraries**: an array of regular expressions that are applied to the linked
+  libraries of a process. This filter does not match on static binaries.
+
+* **contents**: an array of regular expressions that are applied to the memory
+  content of a process. Beware that the regexes are utf-8 and some processes may
+  use non-utf8 encoding internally (java does that). Consider using a byte
+  string to match unusual encoding.
+
+* **bytes**: an array of hexadecimal bytes strings that are search for in the
+  memory content of a process.
+
+Options
+~~~~~~~
+
+Several options can be applied to a search:
+
+* **matchall** indicates that within a given search, all search filters must
+  match on one process for it to be included in the results. Being a boolean,
+  `matchall` is not set by default. The MIG command line sets it automatically,
+  the console does not.
+
+* **offset** can be used to set a non-zero start address used to skip some
+  memory regions when scanning a process. This is useful when scanning very
+  large processes.
+
+* **maxlength** can be used to stop the scanning of the memory of a process when
+  X number of bytes have been read. This is useful when scanning very large
+  processes.
+
+* **logfailures** indicates whether MM should return detailed logs of memory
+  walking failures. Failures happen all the time because processes have regions
+  that are locked and cannot be read. The underlying Masche library does not
+  attempt to force its way through unreadable memory regions by default, but
+  skips and logs them instead.
+
+Memory scanning algorithm
+-------------------------
+
+The memory of a process is read from `offset` until `maxlength` by chunks of 4kB
+by default. If one of the search includes a byte string that's longer than 4kB,
+the size of the buffer is increased to twice the size of the longest byte
+string to accomodate it.
+
+Memory is read sequentially, and the buffer is moved forward by half of its size
+at each iteration, meaning that the memory of a given process is read twice in
+the sliding buffer::
+
+	v-offset										v-maxlength
+	|----------process-memory------------------------------------------------|
+	[--- buffer i=1 ---]
+				[--- buffer i=2 ---]
+							[--- buffer i=3 ---]
+									[--- buffer i=4 ---]STOP
+
+All searches that are currently active are ran on a copy of the buffer. A given
+memory region is only ever read once, regardless of the number of searches being
+performed.
+
+Walking the memory stops either when all the memory has been read, when
+`maxlength` is reached, or as soon as all search filters have matched once.
+

--- a/src/mig/modules/memory/memory.go
+++ b/src/mig/modules/memory/memory.go
@@ -127,7 +127,7 @@ func (s *search) makeChecks() (err error) {
 		}
 	}()
 	if s.Options.MaxLength == 0 {
-		s.Options.MaxLength = float64(^uintptr(0) >> 1)
+		s.Options.MaxLength = float64(^uint64(0))
 	}
 	for _, v := range s.Names {
 		var c check
@@ -552,12 +552,12 @@ func (r Runner) walkProcMemory(proc process.Process, procname string) (err error
 		return
 	}
 	// keep track of the number of bytes read to exit when maxlength is reached
-	readBytes := 0
+	var readBytes float64
 	walkfn := func(curStartAddr uintptr, buf []byte) (keepSearching bool) {
 		if readBytes == 0 {
-			readBytes += len(buf)
+			readBytes += float64(len(buf))
 		} else {
-			readBytes += len(buf) / 2
+			readBytes += float64(len(buf) / 2)
 		}
 		if debug {
 			fmt.Println("walkProcMemory: reading", bufsize, "bytes starting at addr", curStartAddr, "; read", readBytes, "bytes so far")
@@ -569,7 +569,7 @@ func (r Runner) walkProcMemory(proc process.Process, procname string) (err error
 			}
 			// if the search is meant to stop at a given address, and we're passed
 			// that point then deactivate the search now
-			if float64(readBytes) >= search.Options.MaxLength {
+			if readBytes >= search.Options.MaxLength {
 				search.deactivate()
 				goto skip
 			}
@@ -621,7 +621,7 @@ func (r Runner) walkProcMemory(proc process.Process, procname string) (err error
 			}
 		}
 	}
-	stats.MemoryRead += float64(readBytes)
+	stats.MemoryRead += readBytes
 	return
 }
 

--- a/src/mig/modules/memory/memory.go
+++ b/src/mig/modules/memory/memory.go
@@ -99,7 +99,9 @@ type psres struct {
 
 /* Statistic counters:
 - ProcessCount is the total numbers of processes inspected
+- MemoryRead is the total number of bytes of memory inspected
 - Totalhits is the total number of checks that hit
+- Failures is an array of soft errors encountered during inspection
 - Exectime is the total execution time of the module
 */
 type statistics struct {

--- a/src/mig/modules/memory/memory.go
+++ b/src/mig/modules/memory/memory.go
@@ -246,7 +246,7 @@ func validateLabel(label string) error {
 	if len(label) < 1 {
 		return fmt.Errorf("empty labels are not permitted")
 	}
-	labelregexp := `^([a-zA-Z0-9_-]|.){1,64}$`
+	labelregexp := `^([a-zA-Z0-9_-]){1,64}$`
 	labelre := regexp.MustCompile(labelregexp)
 	if !labelre.MatchString(label) {
 		return fmt.Errorf("The syntax of label '%s' is invalid. Must match regex %s", label, labelregexp)
@@ -266,6 +266,8 @@ func validateRegex(regex string) error {
 }
 
 func (r Runner) Run(in io.Reader) (out string) {
+	var ts statistics
+	stats = ts
 	// in debug mode, we just panic
 	if !debug {
 		defer func() {

--- a/src/mig/modules/memory/memory.go
+++ b/src/mig/modules/memory/memory.go
@@ -1,0 +1,837 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
+//              Sushant Dinesh sushant.dinesh94@gmail.com [:sushant94]
+
+package memory
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/mozilla/masche/listlibs"
+	"github.com/mozilla/masche/memaccess"
+	"github.com/mozilla/masche/process"
+	"io"
+	"mig/modules"
+	"regexp"
+	"time"
+)
+
+var debug bool = false
+
+func init() {
+	modules.Register("memory", func() interface{} {
+		return new(Runner)
+	})
+}
+
+type Runner struct {
+	Parameters params
+	Results    modules.Result
+}
+
+type params struct {
+	Searches map[string]search `json:"searches,omitempty"`
+}
+
+func newParameters() *params {
+	var p params
+	p.Searches = make(map[string]search)
+	return &p
+}
+
+type search struct {
+	Description string   `json:"description,omitempty"`
+	Names       []string `json:"names,omitempty"`
+	Libraries   []string `json:"libraries,omitempty"`
+	Bytes       []string `json:"bytes,omitempty"`
+	Contents    []string `json:"contents,omitempty"`
+	Options     options  `json:"options,omitempty"`
+	checks      []check
+	checkmask   checkType
+	isactive    bool
+}
+
+type options struct {
+	Offset      float64 `json:"offset,omitempty"`
+	MaxLength   float64 `json:"maxlength,omitempty"`
+	LogFailures bool    `json:"logfailures,omitempty"`
+	MatchAll    bool    `json:"matchall,omitempty"`
+}
+
+type checkType uint64
+
+// BitMask for the type of check to apply to a given file
+// see documentation about iota for more info
+const (
+	checkName checkType = 1 << (64 - 1 - iota)
+	checkLib
+	checkByte
+	checkContent
+)
+
+type check struct {
+	code      checkType
+	matched   uint64
+	matchedPs []process.Process
+	value     string
+	regex     *regexp.Regexp
+}
+
+type searchResults map[string]searchresult
+
+type searchresult []matchedps
+
+type matchedps struct {
+	Process psres  `json:"process"`
+	Search  search `json:"search"`
+}
+
+type psres struct {
+	Name string  `json:"name"`
+	Pid  float64 `json:"pid"`
+}
+
+/* Statistic counters:
+- ProcessCount is the total numbers of processes inspected
+- Totalhits is the total number of checks that hit
+- Exectime is the total execution time of the module
+*/
+type statistics struct {
+	ProcessCount float64  `json:"processcount"`
+	MemoryRead   float64  `json:"memoryread"`
+	TotalHits    float64  `json:"totalhits"`
+	Failures     []string `json:"failures,omitempty"`
+	Exectime     string   `json:"exectime"`
+}
+
+// global stats variable
+var stats statistics
+
+// newResults allocates a Results structure
+func newResults() *modules.Result {
+	return &modules.Result{Elements: make(searchResults)}
+}
+
+func (s *search) makeChecks() (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("makeChecks() -> %v", e)
+		}
+	}()
+	if s.Options.MaxLength == 0 {
+		s.Options.MaxLength = float64(^uintptr(0) >> 1)
+	}
+	for _, v := range s.Names {
+		var c check
+		c.code = checkName
+		c.value = v
+		c.regex = regexp.MustCompile(v)
+		s.checks = append(s.checks, c)
+		s.checkmask |= c.code
+		if debug {
+			fmt.Printf("adding name check with value '%s'\n", c.value)
+		}
+	}
+	for _, v := range s.Libraries {
+		var c check
+		c.code = checkLib
+		c.value = v
+		c.regex = regexp.MustCompile(v)
+		s.checks = append(s.checks, c)
+		s.checkmask |= c.code
+		if debug {
+			fmt.Printf("adding library check with value '%s'\n", c.value)
+		}
+	}
+	for _, v := range s.Contents {
+		var c check
+		c.code = checkContent
+		c.value = v
+		c.regex = regexp.MustCompile(v)
+		s.checks = append(s.checks, c)
+		s.checkmask |= c.code
+		if debug {
+			fmt.Printf("adding content check with value '%s'\n", c.value)
+		}
+	}
+	for _, v := range s.Bytes {
+		var c check
+		c.code = checkByte
+		c.value = v
+		s.checks = append(s.checks, c)
+		s.checkmask |= c.code
+		if debug {
+			fmt.Printf("adding byte check with value '%s'\n", c.value)
+		}
+	}
+	return
+}
+
+func (s *search) activate() {
+	s.isactive = true
+	return
+}
+
+func (s *search) deactivate() {
+	s.isactive = false
+	return
+}
+
+func (c *check) storeMatch(proc process.Process) {
+	if debug {
+		fmt.Printf("storing process id %d that matched check %d\n",
+			proc.Pid(), c.code)
+	}
+	store := true
+	for _, storedPs := range c.matchedPs {
+		// only store files once per check
+		if proc.Pid() == storedPs.Pid() {
+			store = false
+		}
+	}
+	if store {
+		c.matched++
+		c.matchedPs = append(c.matchedPs, proc)
+	}
+	return
+}
+
+func (r Runner) ValidateParameters() (err error) {
+	var labels []string
+	for label, s := range r.Parameters.Searches {
+		labels = append(labels, label)
+		if debug {
+			fmt.Printf("validating label '%s'\n", label)
+		}
+		err = validateLabel(label)
+		if err != nil {
+			return
+		}
+		for _, r := range s.Contents {
+			if debug {
+				fmt.Printf("validating content '%s'\n", r)
+			}
+			err = validateRegex(r)
+			if err != nil {
+				return
+			}
+		}
+		for _, r := range s.Names {
+			if debug {
+				fmt.Printf("validating name '%s'\n", r)
+			}
+			err = validateRegex(r)
+			if err != nil {
+				return
+			}
+		}
+		for _, r := range s.Libraries {
+			if debug {
+				fmt.Printf("validating library '%s'\n", r)
+			}
+			err = validateRegex(r)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+func validateLabel(label string) error {
+	if len(label) < 1 {
+		return fmt.Errorf("empty labels are not permitted")
+	}
+	labelregexp := `^([a-zA-Z0-9_-]|.){1,64}$`
+	labelre := regexp.MustCompile(labelregexp)
+	if !labelre.MatchString(label) {
+		return fmt.Errorf("The syntax of label '%s' is invalid. Must match regex %s", label, labelregexp)
+	}
+	return nil
+}
+
+func validateRegex(regex string) error {
+	if len(regex) < 1 {
+		return fmt.Errorf("Empty values are not permitted")
+	}
+	_, err := regexp.Compile(regex)
+	if err != nil {
+		return fmt.Errorf("Invalid regexp '%s'. Must be a regexp. Compilation failed with '%v'", regex, err)
+	}
+	return nil
+}
+
+func (r Runner) Run(in io.Reader) (out string) {
+	// in debug mode, we just panic
+	if !debug {
+		defer func() {
+			if e := recover(); e != nil {
+				// return error in json
+				res := newResults()
+				res.Statistics = stats
+				res.Errors = append(res.Errors, fmt.Sprintf("%v", e))
+				res.Success = false
+				err, _ := json.Marshal(res)
+				out = string(err[:])
+				return
+			}
+		}()
+	}
+	t0 := time.Now()
+	err := modules.ReadInputParameters(in, &r.Parameters)
+	if err != nil {
+		panic(err)
+	}
+	err = r.ValidateParameters()
+	if err != nil {
+		panic(err)
+	}
+	// create the checks based on the search parameters
+	for label, search := range r.Parameters.Searches {
+		if debug {
+			fmt.Println("making checks for label", label)
+		}
+		err := search.makeChecks()
+		if err != nil {
+			panic(err)
+		}
+		r.Parameters.Searches[label] = search
+	}
+	// evaluate each process one by one
+	pids, err, serr := process.GetAllPids()
+	if err != nil {
+		panic(err)
+	}
+	if debug {
+		fmt.Println("found", len(pids), "processes to evaluate")
+	}
+	for _, err = range serr {
+		stats.Failures = append(stats.Failures, err.Error())
+	}
+	for _, pid := range pids {
+		// activate all searches
+		for label, search := range r.Parameters.Searches {
+			search.activate()
+			r.Parameters.Searches[label] = search
+		}
+		proc, err, serr := process.OpenFromPid(pid)
+		if err != nil {
+			// if we encounter a hard failure, skip this process
+			stats.Failures = append(stats.Failures, err.Error())
+			continue
+		}
+		for _, err = range serr {
+			// soft failures are just logged but we continue inspection
+			stats.Failures = append(stats.Failures, err.Error())
+		}
+		err = r.evaluateProcess(proc)
+		if err != nil {
+			stats.Failures = append(stats.Failures, err.Error())
+		}
+		stats.ProcessCount++
+	}
+
+	out, err = r.buildResults(t0)
+	if err != nil {
+		panic(err)
+	}
+
+	if debug {
+		fmt.Println("---- results ----")
+		var tmpres modules.Result
+		err = json.Unmarshal([]byte(out), &tmpres)
+		printedResults, err := r.PrintResults(tmpres, false)
+		if err != nil {
+			panic(err)
+		}
+		for _, res := range printedResults {
+			fmt.Println(res)
+		}
+	}
+	return
+}
+
+// evaluateProcess takes a single process and applies searches to it. All searches are evaluated. The `name` and `library`
+// checks are run first, and if needed, the memory of the process is read to run the checks on `contents` and `bytes`.
+// The logic is optimized to only read the process memory once and apply all the checks to it.
+func (r Runner) evaluateProcess(proc process.Process) (err error) {
+	if !debug {
+		defer func() {
+			if e := recover(); e != nil {
+				err = fmt.Errorf("evaluateProcess() -> %v", e)
+			}
+		}()
+	}
+	procname, err, serr := proc.Name()
+	if err != nil {
+		return
+	}
+	for _, err = range serr {
+		stats.Failures = append(stats.Failures, err.Error())
+		if debug {
+			fmt.Printf("evaluateProcess: soft error -> %v\n", err)
+		}
+	}
+	if debug {
+		fmt.Printf("evaluateProcess: evaluating proc %s\n", procname)
+	}
+	// first pass: apply all name & library checks against the current process
+	for label, search := range r.Parameters.Searches {
+		if !search.isactive {
+			goto skip
+		}
+		if !search.checkName(proc, procname) && search.Options.MatchAll {
+			if debug {
+				fmt.Printf("evaluateProcess: proc %s does not match the names of search %s and matchall is set\n",
+					procname, label)
+			}
+			search.deactivate()
+			goto skip
+		}
+		if !search.checkLibraries(proc, procname) && search.Options.MatchAll {
+			if debug {
+				fmt.Printf("evaluateProcess: proc %s does not match the libraries of search %s and matchall is set\n",
+					procname, label)
+			}
+			search.deactivate()
+			goto skip
+		}
+	skip:
+		r.Parameters.Searches[label] = search
+	}
+	// second pass: walk the memory of the process and apply contents regexes and bytes searches
+	return r.walkProcMemory(proc, procname)
+}
+
+// checkName compares the "name" (binary full path) of a process against name checks
+func (s search) checkName(proc process.Process, procname string) (matchedall bool) {
+	matchedall = true
+	if s.checkmask&checkName == 0 {
+		// this search has no name check
+		return
+	}
+	for i, c := range s.checks {
+		if c.code&checkName == 0 {
+			continue
+		}
+		if debug {
+			fmt.Println("checkName: evaluating", procname, proc.Pid(), "against check", c.value)
+		}
+		if c.regex.MatchString(procname) {
+			if debug {
+				fmt.Printf("checkName: proc name '%s' pid %d matches regex '%s'\n",
+					procname, proc.Pid(), c.value)
+			}
+			c.storeMatch(proc)
+		} else {
+			if debug {
+				fmt.Printf("checkName: proc name '%s' pid %d does not match regex '%s'\n",
+					procname, proc.Pid(), c.value)
+			}
+			matchedall = false
+		}
+		s.checks[i] = c
+	}
+	return
+}
+
+// checkLibraries retrieves the linked libraries of a process and compares them with the
+// regexes of library checks
+func (s search) checkLibraries(proc process.Process, procname string) (matchedall bool) {
+	matchedall = true
+	if s.checkmask&checkLib == 0 {
+		// this search has no library check
+		return
+	}
+	for i, c := range s.checks {
+		if c.code&checkLib == 0 {
+			continue
+		}
+		libs, err, serr := listlibs.GetMatchingLoadedLibraries(proc, c.regex)
+		if err != nil {
+			stats.Failures = append(stats.Failures, err.Error())
+		}
+		if len(serr) > 0 && s.Options.LogFailures {
+			stats.Failures = append(stats.Failures, err.Error())
+			if debug {
+				for _, err := range serr {
+					fmt.Printf("checkLibraries: soft error -> %v\n", err)
+				}
+			}
+		}
+		if len(libs) > 0 {
+			if debug {
+				fmt.Printf("checkLibraries: proc name '%s' pid %d has libraries matching regex '%s'\n",
+					procname, proc.Pid(), c.value)
+			}
+			c.storeMatch(proc)
+		} else {
+			matchedall = false
+		}
+		s.checks[i] = c
+	}
+	return
+}
+
+func (r Runner) walkProcMemory(proc process.Process, procname string) (err error) {
+	// find longest byte string to search for, which determines the buffer size
+	bufsize := uint(4096)
+	// find lowest offset, which determines start address
+	offset := ^uintptr(0) >> 1
+	// verify that at least one search is interested in inspecting the memory
+	// of this process
+	shouldWalkMemory := false
+	// if at least one search wants to log failures, do so, otherwise omit them
+	logFailures := false
+	for label, search := range r.Parameters.Searches {
+		// if the search is not active or the search as no content or by check to run, skip it
+		if !search.isactive || (search.checkmask&checkContent == 0 && search.checkmask&checkByte == 0) {
+			search.deactivate()
+			r.Parameters.Searches[label] = search
+			continue
+		}
+		shouldWalkMemory = true
+		// find the largest bufsize needed
+		for _, c := range search.checks {
+			if c.code&checkByte != 0 {
+				if uint(len(c.value)) > bufsize {
+					bufsize = uint(len(c.value))
+					// pad to always have an even bufsize
+					if bufsize%2 != 0 {
+						bufsize++
+					}
+				}
+			}
+		}
+		// find the smallest offset needed
+		if uintptr(search.Options.Offset) < offset {
+			offset = uintptr(search.Options.Offset)
+		}
+		if search.Options.LogFailures {
+			logFailures = true
+		}
+	}
+	if !shouldWalkMemory {
+		if debug {
+			fmt.Println("walkProcMemory: no check needs to read the memory of process", proc.Pid(), procname)
+		}
+		return
+	}
+	// keep track of the number of bytes read to exit when maxlength is reached
+	readBytes := 0
+	walkfn := func(curStartAddr uintptr, buf []byte) (keepSearching bool) {
+		if readBytes == 0 {
+			readBytes += len(buf)
+		} else {
+			readBytes += len(buf) / 2
+		}
+		if debug {
+			fmt.Println("walkProcMemory: reading", bufsize, "bytes starting at addr", curStartAddr, "; read", readBytes, "bytes so far")
+		}
+		for label, search := range r.Parameters.Searches {
+			matchedall := true
+			if !search.isactive {
+				continue
+			}
+			// if the search is meant to stop at a given address, and we're passed
+			// that point then deactivate the search now
+			if float64(readBytes) >= search.Options.MaxLength {
+				search.deactivate()
+				goto skip
+			}
+			keepSearching = true
+			for i, c := range search.checks {
+				switch c.code {
+				case checkContent:
+					if c.regex.FindIndex(buf) == nil {
+						// not found
+						matchedall = false
+						continue
+					}
+					c.storeMatch(proc)
+					search.checks[i] = c
+				case checkByte:
+					if bytes.Index(buf, []byte(c.value)) < 0 {
+						// not found
+						matchedall = false
+						continue
+					}
+					c.storeMatch(proc)
+					search.checks[i] = c
+				}
+			}
+			// if all the checks have matched on this search, deactivate it
+			if matchedall {
+				search.deactivate()
+			}
+		skip:
+			r.Parameters.Searches[label] = search
+		}
+		if debug && !keepSearching {
+			fmt.Println("walkProcMemory: stopping the memory search for", proc.Pid(), procname)
+		}
+		return
+	}
+	if debug {
+		fmt.Println("walkProcMemory: reading memory of", proc.Pid(), procname)
+	}
+	err, serr := memaccess.SlidingWalkMemory(proc, offset, bufsize, walkfn)
+	if err != nil {
+		return err
+	}
+	if logFailures {
+		for _, err = range serr {
+			stats.Failures = append(stats.Failures, err.Error())
+			if debug {
+				fmt.Printf("walkProcMemory: soft error -> %v\n", err)
+			}
+		}
+	}
+	stats.MemoryRead += float64(readBytes)
+	return
+}
+
+func (r Runner) buildResults(t0 time.Time) (resStr string, err error) {
+	// in debug mode, we just panic
+	if !debug {
+		defer func() {
+			if e := recover(); e != nil {
+				err = fmt.Errorf("buildResults() -> %v", e)
+			}
+		}()
+	}
+	res := newResults()
+	for label, search := range r.Parameters.Searches {
+		var sr searchresult
+		// if matchall is set
+		//
+		// all checks in the search must have match on any given process for it
+		// to be included in the results.
+		//
+		// First: we build a list of processes that matched at list one check
+		// in `allProcesses`.
+		// Second: we prune the list of `allProcesses` to only keep the ones that
+		// have matched on all the checks and store it in `matchedProcesses`
+		// Third: we take the list in `matchedProcesses` and retrieve extra details
+		// about the process itself (owner, ...) and store it into results
+		//
+		// An edge case: if the search has not matched on any process, a process
+		// with an empty name and pid 0 is inserted to store the results. This
+		// fake process always indicates that the search has failed to match.
+		if search.Options.MatchAll {
+			var allProcesses, matchedProcesses []process.Process
+			// First: collect all the processes that were found across all
+			// checks of this search, don't store duplicates
+			for _, c := range search.checks {
+				for _, matchedPs := range c.matchedPs {
+					store := true
+					for _, aps := range allProcesses {
+						if aps.Pid() == matchedPs.Pid() {
+							store = false
+						}
+					}
+					if store {
+						allProcesses = append(allProcesses, matchedPs)
+					}
+				}
+			}
+			// Second: prune the list to only keep the processes that matched
+			// all checks
+			for _, aps := range allProcesses {
+				if debug {
+					fmt.Println("checking if process", aps.Pid(), "matched all checks")
+				}
+				matchedallchecks := true
+				for _, c := range search.checks {
+					found := false
+					for _, matchedPs := range c.matchedPs {
+						if aps.Pid() == matchedPs.Pid() {
+							found = true
+						}
+					}
+					if !found {
+						if debug {
+							fmt.Println("check", c.code, "did not match")
+						}
+						matchedallchecks = false
+						break
+					}
+				}
+				if matchedallchecks {
+					matchedProcesses = append(matchedProcesses, aps)
+				}
+			}
+			if len(matchedProcesses) == 0 {
+				var nullPs process.Process
+				matchedProcesses = append(matchedProcesses, nullPs)
+			}
+			// Third: we have a clean list of files that matched all checks,
+			// store it as search results
+			for _, matchedPs := range matchedProcesses {
+				var mps matchedps
+				if matchedPs == nil {
+					mps.Process.Name = ""
+					mps.Process.Pid = 0
+				} else {
+					// we don't check for errors here, that's been done before
+					mps.Process.Name, _, _ = matchedPs.Name()
+					mps.Process.Pid = float64(matchedPs.Pid())
+					stats.TotalHits++
+					// TODO: get detailed info about process here
+				}
+				mps.Search = search
+				// reset option fields so they get omitted
+				mps.Search.Options.Offset = 0.0
+				mps.Search.Options.MaxLength = 0.0
+				mps.Search.Options.MatchAll = search.Options.MatchAll
+				sr = append(sr, mps)
+			}
+			// done with this search, go to the next one
+			goto nextsearch
+		}
+
+		// if matchall is not set (and the goto above wasn't called)
+		//
+		// now that `matchall` is handled, go through the list of processes and store
+		// them into the searchresults structure, with the corresponding checks that matched
+		for _, c := range search.checks {
+			// if this check matched nothing, store it in a search result
+			// where the File value is the empty string
+			if len(c.matchedPs) == 0 {
+				var nullps process.Process
+				c.matchedPs = append(c.matchedPs, nullps)
+			}
+			for _, matchedPs := range c.matchedPs {
+				var mps matchedps
+				if matchedPs == nil {
+					mps.Process.Name = ""
+					mps.Process.Pid = 0
+				} else {
+					// we don't check for errors here, that's been done before
+					mps.Process.Name, _, _ = matchedPs.Name()
+					mps.Process.Pid = float64(matchedPs.Pid())
+					stats.TotalHits++
+					// TODO: get detailed info about process here
+				}
+				// reset option fields so they get omitted
+				mps.Search.Options.Offset = 0.0
+				mps.Search.Options.MaxLength = 0.0
+				mps.Search.Options.MatchAll = search.Options.MatchAll
+				switch c.code {
+				case checkContent:
+					mps.Search.Contents = append(mps.Search.Contents, c.value)
+				case checkName:
+					mps.Search.Names = append(mps.Search.Names, c.value)
+				case checkLib:
+					mps.Search.Libraries = append(mps.Search.Libraries, c.value)
+				case checkByte:
+					mps.Search.Bytes = append(mps.Search.Bytes, c.value)
+				}
+				sr = append(sr, mps)
+			}
+		}
+	nextsearch:
+		res.Elements.(searchResults)[label] = sr
+	}
+
+	// calculate execution time
+	t1 := time.Now()
+	stats.Exectime = t1.Sub(t0).String()
+	if debug {
+		fmt.Printf("storing exectime %s\n", stats.Exectime)
+	}
+	// store the stats in the response
+	res.Statistics = stats
+	// execution succeeded, set Success to true
+	res.Success = true
+	if stats.TotalHits > 0 {
+		res.FoundAnything = true
+	}
+	if debug {
+		fmt.Printf("Processes Count:  %.0f\n"+
+			"Memory read:      %.0f bytes\n"+
+			"Total hits:       %.0f\n"+
+			"Failures:         %d\n"+
+			"Execution time:   %s\n",
+			stats.ProcessCount, stats.MemoryRead,
+			stats.TotalHits, len(stats.Failures), stats.Exectime)
+	}
+	JsonResults, err := json.Marshal(res)
+	if err != nil {
+		panic(err)
+	}
+	resStr = string(JsonResults[:])
+	if debug {
+		fmt.Println(resStr)
+	}
+	return
+}
+
+// PrintResults() returns results in a human-readable format. if foundOnly is set,
+// only results that have at least one match are returned.
+// If foundOnly is not set, all results are returned, along with errors and
+// statistics.
+func (r Runner) PrintResults(result modules.Result, foundOnly bool) (prints []string, err error) {
+	var (
+		el    searchResults
+		stats statistics
+	)
+	err = result.GetElements(&el)
+	if err != nil {
+		panic(err)
+	}
+	err = result.GetStatistics(&stats)
+	if err != nil {
+		panic(err)
+	}
+
+	for label, sr := range el {
+		for _, mps := range sr {
+			var out string
+			if mps.Process.Name == "" {
+				if foundOnly {
+					continue
+				}
+				out = fmt.Sprintf("0 match found in search '%s'", label)
+			} else {
+				out = fmt.Sprintf("%s [pid:%.0f] in search '%s'",
+					mps.Process.Name, mps.Process.Pid, label)
+			}
+			if mps.Search.Options.MatchAll {
+				prints = append(prints, out)
+				continue
+			}
+			out += " on checks"
+			// if matchany, print the detail of the checks that matched with the filename
+			for _, v := range mps.Search.Names {
+				out += fmt.Sprintf(" name='%s'", v)
+			}
+			for _, v := range mps.Search.Libraries {
+				out += fmt.Sprintf(" library='%s'", v)
+			}
+			for _, v := range mps.Search.Contents {
+				out += fmt.Sprintf(" content='%s'", v)
+			}
+			for _, v := range mps.Search.Bytes {
+				out += fmt.Sprintf(" byte='%s'", v)
+			}
+			prints = append(prints, out)
+		}
+	}
+	if !foundOnly {
+		for _, e := range stats.Failures {
+			prints = append(prints, fmt.Sprintf("Failure: %v", e))
+		}
+		for _, e := range result.Errors {
+			prints = append(prints, e)
+		}
+		stat := fmt.Sprintf("Statistics: %.0f processes checked, %.0f matched, %d failures, ran in %s.",
+			stats.ProcessCount, stats.TotalHits, len(stats.Failures), stats.Exectime)
+		prints = append(prints, stat)
+	}
+	return
+}

--- a/src/mig/modules/memory/memory_test.go
+++ b/src/mig/modules/memory/memory_test.go
@@ -109,7 +109,7 @@ func TestSearches(t *testing.T) {
 	var parameters = []testParams{
 		{true, `{"searches":{"s1":{"names":["go"]}}}`},
 		{false, `{"searches":{"s1":{"libraries":["^caribou.so$"]}}}`},
-		{true, `{"searches":{"s1":{"contents":["memory_test"]}}}`},
+		{true, `{"searches":{"s1":{"contents":["memory_test"], "names": ["go"]}}}`},
 		{false, `{"searches":{"s1":{"names":["1983yrotewdshhhoiufhes7fd29"],"bytes":["ffffffffaaaabbbbcccceeee"],"options":{"matchall": true}}}}`},
 	}
 	for _, tp := range parameters {

--- a/src/mig/modules/memory/memory_test.go
+++ b/src/mig/modules/memory/memory_test.go
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
+package memory
+
+import (
+	"bytes"
+	"encoding/json"
+	"mig/modules"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	if _, ok := modules.Available["memory"]; !ok {
+		t.Fatalf("module registration failed")
+	}
+}
+
+type testParams struct {
+	expect bool
+	params string
+}
+
+func TestParameters(t *testing.T) {
+	var (
+		r   Runner
+		err error
+	)
+	var parameters = []testParams{
+		{true, `{"searches":{"s1":{"names":["foo"],"libraries":["bar"],"bytes":["abcd"]}}}`},
+		{false, `{"searches":{"*&^!*@&#^*!":{"names":["foo"]}}}`},
+		{false, `{"searches":{"":{"names":["foo"]}}}`},
+		{false, `{"searches":{"s1":{"names":["["]}}}`},
+		{false, `{"searches":{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":{"names":["foo"]}}}`},
+		{true, `{"searches":{"s1":{"libraries":["^[a-z]{10,50}$"]}}}`},
+		{false, `{"searches":{"s1":{"libraries":["["]}}}`},
+		{true, `{"searches":{"s1":{"bytes":["abc","def","ghij"]}}}`},
+		{true, `{"searches":{"s1":{"contents":["^(.+)[a-zA-Z0-9]{10.50}$"]}}}`},
+		{false, `{"searches":{"s1":{"contents":["^$", "["]}}}`},
+	}
+	for _, tp := range parameters {
+		r.Parameters = *newParameters()
+		err = json.Unmarshal([]byte(tp.params), &r.Parameters)
+		if err != nil && tp.expect {
+			t.Fatal(err)
+		}
+		err = r.ValidateParameters()
+		if err == nil && !tp.expect {
+			t.Fatalf("invalid parameters '%s' considered valid", tp.params)
+		} else if err != nil && tp.expect {
+			t.Fatalf("valid parameters '%s' considered invalid: %v", tp.params, err)
+		}
+	}
+}
+
+func TestFindGoTestProcess(t *testing.T) {
+	var (
+		r Runner
+		s search
+	)
+	r.Parameters = *newParameters()
+	s.Names = append(s.Names, "go-build")
+	marker := "test search looking for self"
+	s.Bytes = append(s.Bytes, marker)
+	s.Contents = append(s.Contents, marker)
+	s.Description = marker
+	s.Options.MatchAll = true
+	s.Options.Offset = 0.0
+	s.Options.MaxLength = 10000000
+	s.Options.LogFailures = true
+	r.Parameters.Searches["testsearch"] = s
+	msg, err := modules.MakeMessage(modules.MsgClassParameters, r.Parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := r.Run(bytes.NewBuffer(msg))
+	if len(out) == 0 {
+		t.Fatal("run failed")
+	}
+	t.Log(out)
+	err = json.Unmarshal([]byte(out), &r.Results)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Results.Success {
+		t.Fatal("failed to run memory search")
+	}
+	if !r.Results.FoundAnything {
+		t.Fatal("should have found own go test process but didn't")
+	}
+	prints, err := r.PrintResults(r.Results, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prints) < 2 {
+		t.Fatal("not enough results printed")
+	}
+	prints, err = r.PrintResults(r.Results, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prints) != 1 {
+		t.Fatal("wrong number of results, should be one")
+	}
+}
+
+func TestSearches(t *testing.T) {
+	var parameters = []testParams{
+		{true, `{"searches":{"s1":{"names":["go"]}}}`},
+		{false, `{"searches":{"s1":{"libraries":["^caribou.so$"]}}}`},
+		{true, `{"searches":{"s1":{"contents":["memory_test"]}}}`},
+		{false, `{"searches":{"s1":{"names":["1983yrotewdshhhoiufhes7fd29"],"bytes":["qiuwhd191h8eoiqhfa8a9ds10woadhfr872iyeaf78dy28qafwi1094898wydihsf"],"options":{"matchall": true}}}}`},
+	}
+	for _, tp := range parameters {
+		var r Runner
+		r.Parameters = *newParameters()
+		err := json.Unmarshal([]byte(tp.params), &r.Parameters)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg, err := modules.MakeMessage(modules.MsgClassParameters, r.Parameters)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := r.Run(bytes.NewBuffer(msg))
+		if len(out) == 0 {
+			t.Fatal("run failed")
+		}
+		t.Log(out)
+		err = json.Unmarshal([]byte(out), &r.Results)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !r.Results.Success {
+			t.Fatal("failed to run memory search")
+		}
+		if r.Results.FoundAnything && !tp.expect {
+			t.Fatalf("found something for search '%s' and shouldn't have", tp.params)
+		} else if !r.Results.FoundAnything && tp.expect {
+			t.Fatalf("found nothing for search '%s' and should have", tp.params)
+		}
+	}
+}

--- a/src/mig/modules/memory/memory_test.go
+++ b/src/mig/modules/memory/memory_test.go
@@ -36,7 +36,8 @@ func TestParameters(t *testing.T) {
 		{false, `{"searches":{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":{"names":["foo"]}}}`},
 		{true, `{"searches":{"s1":{"libraries":["^[a-z]{10,50}$"]}}}`},
 		{false, `{"searches":{"s1":{"libraries":["["]}}}`},
-		{true, `{"searches":{"s1":{"bytes":["abc","def","ghij"]}}}`},
+		{true, `{"searches":{"s1":{"bytes":["dead","beef"]}}}`},
+		{false, `{"searches":{"s1":{"bytes":["zzzzzzzz"]}}}`},
 		{true, `{"searches":{"s1":{"contents":["^(.+)[a-zA-Z0-9]{10.50}$"]}}}`},
 		{false, `{"searches":{"s1":{"contents":["^$", "["]}}}`},
 	}
@@ -62,10 +63,8 @@ func TestFindGoTestProcess(t *testing.T) {
 	)
 	r.Parameters = *newParameters()
 	s.Names = append(s.Names, "go-build")
-	marker := "test search looking for self"
-	s.Bytes = append(s.Bytes, marker)
-	s.Contents = append(s.Contents, marker)
-	s.Description = marker
+	s.Bytes = append(s.Bytes, "7465737420736561726368206c6f6f6b696e6720666f722073656c66")
+	s.Contents = append(s.Contents, "test search looking for self")
 	s.Options.MatchAll = true
 	s.Options.Offset = 0.0
 	s.Options.MaxLength = 10000000
@@ -111,7 +110,7 @@ func TestSearches(t *testing.T) {
 		{true, `{"searches":{"s1":{"names":["go"]}}}`},
 		{false, `{"searches":{"s1":{"libraries":["^caribou.so$"]}}}`},
 		{true, `{"searches":{"s1":{"contents":["memory_test"]}}}`},
-		{false, `{"searches":{"s1":{"names":["1983yrotewdshhhoiufhes7fd29"],"bytes":["qiuwhd191h8eoiqhfa8a9ds10woadhfr872iyeaf78dy28qafwi1094898wydihsf"],"options":{"matchall": true}}}}`},
+		{false, `{"searches":{"s1":{"names":["1983yrotewdshhhoiufhes7fd29"],"bytes":["ffffffffaaaabbbbcccceeee"],"options":{"matchall": true}}}}`},
 	}
 	for _, tp := range parameters {
 		var r Runner

--- a/src/mig/modules/memory/params.go
+++ b/src/mig/modules/memory/params.go
@@ -1,0 +1,253 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
+
+package memory
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func printHelp(isCmd bool) {
+	dash := ""
+	ma := "off"
+	notma := "on"
+	if isCmd {
+		dash = "-"
+		ma = "on"
+		notma = "off"
+	}
+	fmt.Printf(`Search parameters
+-----------------
+%sname <regex>	- regex to match against the name of a process
+		  ex: %sname ^postgresql$
+
+%slib <regex>	- regex to match processes that are linked to a given library
+		  ex: %slib libssl.so.1.0.0
+
+%scontent <regex> - regex to match against the memory of a process.
+		  note that regexes match utf-8 character sets, and some processes
+		  may use utf-16 or some other encoding internally
+		  ex: %scontent "http://mig\.mozilla\.org"
+
+%sbytes <hex>	- match an hex byte string against the memory of a process
+		  ex: %sbyte "6d69672e6d6f7a696c6c612e6f7267"
+		             (mig.mozilla.org)
+Options
+-------
+%smatchall	- all search parameters must match on a given process for it to
+		  return as a match. %s by default.
+		  ex: %smatchall
+%smatchany	- any search parameter must match on a given process for it to
+		  return as a match. %s by default.
+		  ex: %smatchany
+%slogfailures	- return any failure encountered during scanning. There is usually
+		  a fair amount of them due to memory regions that cannot be read.
+		  ex: %slogfailures
+%soffset <int>	- provide a memory offset to start the scan at
+%smaxlength <int> - indicates if a search should stop after reading <int> bytes
+		    from a process
+detailled doc at http://mig.mozilla.org/doc/module_memory.html
+`, dash, dash, dash, dash, dash, dash, dash, dash, dash, ma,
+		dash, dash, notma, dash, dash, dash, dash, dash)
+	return
+}
+
+// ParamsCreator implements an interactive parameters creation interface, which
+// receives user input,  stores it into a Parameters structure, validates it,
+// and returns that structure as an interface. It is mainly used by the MIG Console
+func (r Runner) ParamsCreator() (interface{}, error) {
+	var err error
+	p := newParameters()
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		var label string
+		var search search
+		for {
+			fmt.Println("Give a name to this search, or 'done' to exit")
+			fmt.Printf("label> ")
+			scanner.Scan()
+			if err := scanner.Err(); err != nil {
+				fmt.Println("Invalid input. Try again")
+				continue
+			}
+			label = scanner.Text()
+			if label == "done" {
+				// no label to add, exit
+				goto exit
+			}
+			if label == "help" {
+				fmt.Println(`A search must first have a name before search parameters can be defined.`)
+				continue
+			}
+			err = validateLabel(label)
+			if err != nil {
+				fmt.Printf("ERROR: %v\nTry again.\n", err)
+				continue
+			}
+			if _, exist := p.Searches[label]; exist {
+				fmt.Printf("A search labelled", label, "already exist. Override it?\n(y/n)> ")
+				scanner.Scan()
+				if err := scanner.Err(); err != nil {
+					fmt.Println("Invalid input.")
+					continue
+				}
+				response := scanner.Text()
+				if response == "y" {
+					fmt.Println("Overriding search", label)
+					break
+				}
+				fmt.Println("Not overriding search", label)
+				continue
+			}
+			break
+		}
+		fmt.Printf("Creating new search with label '%s'\n"+
+			"Enter 'help' to list available parameters.\n", label)
+
+		for {
+			fmt.Printf("search '%s'> ", label)
+			scanner.Scan()
+			if err := scanner.Err(); err != nil {
+				fmt.Println("Invalid input. Try again")
+				continue
+			}
+			input := scanner.Text()
+			if input == "done" {
+				break
+			}
+			if input == "help" {
+				printHelp(false)
+				continue
+			}
+			arr := strings.SplitN(input, " ", 2)
+			checkType := arr[0]
+			checkValue := ""
+			if len(arr) > 1 {
+				checkValue = arr[1]
+			}
+			switch checkType {
+			case "name":
+				err = validateRegex(checkValue)
+				if err != nil {
+					fmt.Printf("ERROR: %v\nTry again.\n", err)
+					continue
+				}
+				search.Names = append(search.Names, checkValue)
+			case "lib":
+				err = validateRegex(checkValue)
+				if err != nil {
+					fmt.Printf("ERROR: %v\nTry again.\n", err)
+					continue
+				}
+				search.Libraries = append(search.Libraries, checkValue)
+			case "bytes":
+				err = validateBytes(checkValue)
+				if err != nil {
+					fmt.Printf("ERROR: %v\nTry again.\n", err)
+					continue
+				}
+				search.Bytes = append(search.Bytes, checkValue)
+			case "content":
+				err = validateRegex(checkValue)
+				if err != nil {
+					fmt.Printf("ERROR: %v\nTry again.\n", err)
+					continue
+				}
+				search.Contents = append(search.Contents, checkValue)
+			case "matchall":
+				search.Options.MatchAll = true
+			case "matchany":
+				search.Options.MatchAll = false
+			case "offset":
+				search.Options.Offset, err = strconv.ParseFloat(checkValue, 10)
+				if err != nil {
+					fmt.Printf("ERROR: %v\nTry again.\n", err)
+					continue
+				}
+			case "maxlength":
+				search.Options.MaxLength, err = strconv.ParseFloat(checkValue, 10)
+				if err != nil {
+					fmt.Printf("ERROR: %v\nTry again.\n", err)
+					continue
+				}
+			case "logfailures":
+				search.Options.LogFailures = true
+			default:
+				fmt.Printf("Invalid method!\n")
+				continue
+			}
+			fmt.Printf("Stored %s %s\nEnter a new parameter, or 'done' to exit.\n", checkType, checkValue)
+		}
+		p.Searches[label] = search
+		fmt.Println("Stored search", label)
+	}
+exit:
+	r.Parameters = *p
+	return r.Parameters, r.ValidateParameters()
+}
+
+// ParamsParser implements a command line parameters parser that takes a string
+// and returns a Parameters structure in an interface. It will display the module
+// help if the arguments string spell the work 'help'
+func (r Runner) ParamsParser(args []string) (interface{}, error) {
+	var (
+		err                               error
+		names, libraries, bytes, contents flagParam
+		offset, maxlength                 float64
+		matchall, matchany, logfailures   bool
+		fs                                flag.FlagSet
+	)
+	if len(args) < 1 || args[0] == "" || args[0] == "help" {
+		printHelp(true)
+		return nil, nil
+	}
+	fs.Init("memory", flag.ContinueOnError)
+	fs.Var(&names, "name", "see help")
+	fs.Var(&libraries, "lib", "see help")
+	fs.Var(&bytes, "bytes", "see help")
+	fs.Var(&contents, "content", "see help")
+	fs.Float64Var(&offset, "maxdepth", 0, "see help")
+	fs.Float64Var(&maxlength, "matchlimit", 0, "see help")
+	fs.BoolVar(&matchall, "matchall", true, "see help")
+	fs.BoolVar(&matchany, "matchany", false, "see help")
+	fs.BoolVar(&logfailures, "logfailures", false, "see help")
+	err = fs.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+	var s search
+	s.Names = names
+	s.Libraries = libraries
+	s.Bytes = bytes
+	s.Contents = contents
+	s.Options.Offset = offset
+	s.Options.MaxLength = maxlength
+	s.Options.MatchAll = matchall
+	if matchany {
+		s.Options.MatchAll = false
+	}
+	s.Options.LogFailures = logfailures
+	p := newParameters()
+	p.Searches["s1"] = s
+	r.Parameters = *p
+	return r.Parameters, r.ValidateParameters()
+}
+
+type flagParam []string
+
+func (f *flagParam) String() string {
+	return fmt.Sprint([]string(*f))
+}
+
+func (f *flagParam) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}

--- a/src/mig/modules/modules_test.go
+++ b/src/mig/modules/modules_test.go
@@ -26,16 +26,16 @@ func TestRegister(t *testing.T) {
 		return new(testRunner)
 	})
 	if _, ok := Available["testing"]; !ok {
-		t.Errorf("testing module registration failed")
+		t.Fatalf("testing module registration failed")
 	}
 	// test availability of unregistered module
 	if _, ok := Available["shouldnotberegistered"]; ok {
-		t.Errorf("testing module availability failed")
+		t.Fatalf("testing module availability failed")
 	}
 	// test registration of already registered module
 	defer func() {
 		if r := recover(); r == nil {
-			t.Errorf("failed to panic on double registration of testing module")
+			t.Fatalf("failed to panic on double registration of testing module")
 		}
 	}()
 	Register("testing", func() interface{} {
@@ -48,18 +48,18 @@ func TestMakeMessage(t *testing.T) {
 	p.SomeParam = "foo"
 	raw, err := MakeMessage(MsgClassParameters, p)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf(err.Error())
 	}
 	if string(raw) != `{"class":"parameters","parameters":{"someparam":"foo"}}` {
-		t.Errorf("Invalid module message class `parameters`")
+		t.Fatalf("Invalid module message class `parameters`")
 	}
 
 	raw, err = MakeMessage(MsgClassStop, nil)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf(err.Error())
 	}
 	if string(raw) != `{"class":"stop"}` {
-		t.Errorf("Invalid module message class `stop`")
+		t.Fatalf("Invalid module message class `stop`")
 	}
 }
 
@@ -77,10 +77,10 @@ func TestGetElements(t *testing.T) {
 	var el element
 	err := r.GetElements(&el)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf(err.Error())
 	}
 	if el.SomeElement != "foo" {
-		t.Errorf("failed to get element from module results")
+		t.Fatalf("failed to get element from module results")
 	}
 
 }
@@ -99,10 +99,10 @@ func TestGetStatistics(t *testing.T) {
 	var stats statistics
 	err := r.GetStatistics(&stats)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf(err.Error())
 	}
 	if stats.SomeCounter != 16.64 {
-		t.Errorf("failed to get statistics from module results")
+		t.Fatalf("failed to get statistics from module results")
 	}
 }
 
@@ -111,10 +111,10 @@ func TestReadInputParameters(t *testing.T) {
 	w := strings.NewReader(`{"class":"parameters","parameters":{"someparam":"foo"}}`)
 	err := ReadInputParameters(w, &p)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf(err.Error())
 	}
 	if p.SomeParam != "foo" {
-		t.Errorf("failed to read input parameters from stdin")
+		t.Fatalf("failed to read input parameters from stdin")
 	}
 	// test delayed write. use a pipe so that reader doesn't reach EOF on the first
 	// read of the empty buffer.
@@ -130,13 +130,13 @@ func TestReadInputParameters(t *testing.T) {
 	select {
 	case <-block:
 	case <-time.After(2 * time.Second):
-		t.Errorf("input parameters read timed out")
+		t.Fatalf("input parameters read timed out")
 	}
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf(err.Error())
 	}
 	if p.SomeParam != "bar" {
-		t.Errorf("failed to read input parameters")
+		t.Fatalf("failed to read input parameters")
 	}
 }
 
@@ -151,6 +151,6 @@ func TestWatchForStop(t *testing.T) {
 	case <-stopChan:
 		break
 	case <-time.After(1 * time.Second):
-		t.Errorf("failed to catch stop message")
+		t.Fatalf("failed to catch stop message")
 	}
 }


### PR DESCRIPTION
This is a rewrite of #48 to use a logic closer to the `file` module, but for scanning memory. The code works. It needs the params parsers and creator, some documentation and tests.

Here's a sample run, matching a string from an email I have open in one of my firefox tab:

```json
$ sudo ./bin/linux/amd64/mig-agent-latest -m memory <<< '{"class":"parameters", "parameters": { "searches": { "s1": { "names": [ "firefox" ], "contents": ["Michal Zalewski discovered multiple vulnerabilities in SQLite"], "options": { "matchall": true } } } } }' 2>/dev/null | j
{
    "elements": {
        "s1": [
            {
                "process": {
                    "name": "/usr/lib64/firefox/firefox",
                    "pid": 24767
                },
                "search": {
                    "contents": [
                        "Michal Zalewski discovered multiple vulnerabilities in SQLite"
                    ],
                    "names": [
                        "firefox"
                    ],
                    "options": {
                        "matchall": true
                    }
                }
            }
        ]
    },
    "errors": null,
    "foundanything": true,
    "statistics": {
        "exectime": "509.114425ms",
        "memoryread": 177563648.0,
        "processcount": 257,
        "totalhits": 1
    },
    "success": true
}
```