### PR TITLE
factor out testing for correct module registration

### DIFF
--- a/src/mig/modules/agentdestroy/agentdestroy_test.go
+++ b/src/mig/modules/agentdestroy/agentdestroy_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Dustin J. Mitchell <dustin@mozilla.com>
+package agentdestroy
+
+import (
+	"mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "agentdestroy")
+}

--- a/src/mig/modules/example/example_test.go
+++ b/src/mig/modules/example/example_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Dustin J. Mitchell <dustin@mozilla.com>
+package example
+
+import (
+	"mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "example")
+}

--- a/src/mig/modules/file/file_test.go
+++ b/src/mig/modules/file/file_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Dustin J. Mitchell <dustin@mozilla.com>
+package file
+
+import (
+	"mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "file")
+}

--- a/src/mig/modules/memory/memory_test.go
+++ b/src/mig/modules/memory/memory_test.go
@@ -9,13 +9,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"mig/modules"
+	"mig/testutil"
 	"testing"
 )
 
 func TestRegistration(t *testing.T) {
-	if _, ok := modules.Available["memory"]; !ok {
-		t.Fatalf("module registration failed")
-	}
+	testutil.CheckModuleRegistration(t, "memory")
 }
 
 type testParams struct {

--- a/src/mig/modules/netstat/netstat_test.go
+++ b/src/mig/modules/netstat/netstat_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Dustin J. Mitchell <dustin@mozilla.com>
+package netstat
+
+import (
+	"mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "netstat")
+}

--- a/src/mig/modules/ping/ping_test.go
+++ b/src/mig/modules/ping/ping_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Dustin J. Mitchell <dustin@mozilla.com>
+package ping
+
+import (
+	"mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "ping")
+}

--- a/src/mig/modules/timedrift/timedrift_test.go
+++ b/src/mig/modules/timedrift/timedrift_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Dustin J. Mitchell <dustin@mozilla.com>
+package timedrift
+
+import (
+	"mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "timedrift")
+}

--- a/src/mig/modules/upgrade/upgrade_test.go
+++ b/src/mig/modules/upgrade/upgrade_test.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Dustin J. Mitchell <dustin@mozilla.com>
+package upgrade
+
+import (
+	"mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "upgrade")
+}

--- a/src/mig/testutil/modtest.go
+++ b/src/mig/testutil/modtest.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"mig/modules"
+	"testing"
+)
+
+func CheckModuleRegistration(t *testing.T, module_name string) {
+	registration, ok := modules.Available[module_name]
+	if !ok {
+		t.Fatalf("module %s not registered", module_name)
+	}
+
+	modRunner := registration.Runner()
+	if _, ok := modRunner.(modules.Moduler); !ok {
+		t.Fatalf("module %s registration function does not return a Moduler",
+			module_name)
+	}
+}


### PR DESCRIPTION
This adds a test script for each existing module, which just verifies that it's registered and that the registered function returns an object that can be cast to the `modules.Moduler` interface.  Baby steps :)