### PR TITLE
New mig module to execute data fingerprints

### DIFF
--- a/conf/available_modules.go
+++ b/conf/available_modules.go
@@ -12,6 +12,7 @@ import (
 	_ "mig/modules/netstat"
 	_ "mig/modules/ping"
 	_ "mig/modules/pkg"
+	_ "mig/modules/pkgprint"
 	_ "mig/modules/timedrift"
 	//_ "mig/modules/upgrade"
 	//_ "mig/modules/example"

--- a/src/mig/modules/pkgprint/paramscreator.go
+++ b/src/mig/modules/pkgprint/paramscreator.go
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+package pkgprint
+
+import (
+	"flag"
+	"fmt"
+)
+
+func printHelp(isCmd bool) {
+	dash := ""
+	if isCmd {
+		dash = "-"
+	}
+	fmt.Printf(`Query parameters
+----------------
+%stemplate <name>   - Scan using template
+                    ex: template mediawiki
+		    query for specific module supplied template
+`, dash)
+}
+
+func (r Runner) ParamsParser(args []string) (interface{}, error) {
+	var (
+		fs           flag.FlagSet
+		templateName string
+	)
+
+	if len(args) < 1 || args[0] == "" || args[0] == "help" {
+		printHelp(true)
+		return nil, nil
+	}
+
+	fs.Init("pkgprint", flag.ContinueOnError)
+	fs.StringVar(&templateName, "template", "", "see help")
+	err := fs.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+
+	p := newParameters()
+	if templateName != "" {
+		p.TemplateParams.Name = templateName
+		p.TemplateMode = true
+	}
+
+	r.Parameters = *p
+
+	return r.Parameters, r.ValidateParameters()
+}

--- a/src/mig/modules/pkgprint/paramscreator.go
+++ b/src/mig/modules/pkgprint/paramscreator.go
@@ -28,6 +28,14 @@ func printHelp(isCmd bool) {
 %sroot <path>       - Specify search root
                     ex: root /usr/local
 		    default root is /
+
+Available templates:
+
+linuxkernel         - Running Linux kernel information
+linuxmodules        - Loaded Linux modules
+pythonegg           - Python package versions
+django              - Django framework versions
+mediawiki           - MediaWiki framework versions
 `, dash, dash, dash)
 }
 

--- a/src/mig/modules/pkgprint/paramscreator.go
+++ b/src/mig/modules/pkgprint/paramscreator.go
@@ -20,13 +20,23 @@ func printHelp(isCmd bool) {
 %stemplate <name>   - Scan using template
                     ex: template mediawiki
 		    query for specific module supplied template
-`, dash)
+
+%sdepth <int>       - Specify maximum directory search depth
+                    ex: depth 2
+		    default depth is 10
+
+%sroot <path>       - Specify search root
+                    ex: root /usr/local
+		    default root is /
+`, dash, dash, dash)
 }
 
 func (r Runner) ParamsParser(args []string) (interface{}, error) {
 	var (
 		fs           flag.FlagSet
 		templateName string
+		depth        int
+		root         string
 	)
 
 	if len(args) < 1 || args[0] == "" || args[0] == "help" {
@@ -36,6 +46,8 @@ func (r Runner) ParamsParser(args []string) (interface{}, error) {
 
 	fs.Init("pkgprint", flag.ContinueOnError)
 	fs.StringVar(&templateName, "template", "", "see help")
+	fs.IntVar(&depth, "depth", 10, "see help")
+	fs.StringVar(&root, "root", "/", "see help")
 	err := fs.Parse(args)
 	if err != nil {
 		return nil, err
@@ -46,6 +58,8 @@ func (r Runner) ParamsParser(args []string) (interface{}, error) {
 		p.TemplateParams.Name = templateName
 		p.TemplateMode = true
 	}
+	p.SearchDepth = depth
+	p.SearchRoot = root
 
 	r.Parameters = *p
 

--- a/src/mig/modules/pkgprint/pkgprint.go
+++ b/src/mig/modules/pkgprint/pkgprint.go
@@ -55,6 +55,16 @@ func executeTemplate(tname string, depth int, root string) (FPResult, error) {
 	}
 	s.Locate(fp.filename, fp.isRegexp)
 	for _, x := range s.matches {
+		// If a path filter exists and does not match the file, ignore
+		// it.
+		if fp.pathFilter != "" {
+			var flag bool
+			flag, err = regexp.MatchString(fp.pathFilter, x)
+			if err != nil || !flag {
+				continue
+			}
+		}
+
 		// If an error occurs here, just ignore it and keep going.
 		m, _ := FileContentCheck(x, fp.contentMatch)
 		if len(m) == 0 {

--- a/src/mig/modules/pkgprint/pkgprint.go
+++ b/src/mig/modules/pkgprint/pkgprint.go
@@ -53,6 +53,13 @@ func executeTemplate(tname string, depth int, root string) (FPResult, error) {
 	if root != "/" {
 		s.root = root
 	}
+
+	// If the fingerprint has a forced root, override the root that has
+	// been specified.
+	if fp.forceRoot != "" {
+		s.root = fp.forceRoot
+	}
+
 	s.Locate(fp.filename, fp.isRegexp)
 	for _, x := range s.matches {
 		// If a path filter exists and does not match the file, ignore

--- a/src/mig/modules/pkgprint/pkgprint.go
+++ b/src/mig/modules/pkgprint/pkgprint.go
@@ -74,7 +74,7 @@ func executeTemplate(tname string, depth int, root string) (FPResult, error) {
 
 		// If an error occurs here, just ignore it and keep going.
 		m, _ := FileContentCheck(x, fp.contentMatch)
-		if len(m) == 0 {
+		if m == nil || len(m) == 0 {
 			continue
 		}
 		for _, i := range m {

--- a/src/mig/modules/pkgprint/pkgprint.go
+++ b/src/mig/modules/pkgprint/pkgprint.go
@@ -1,0 +1,326 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+package pkgprint
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mig/modules"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+)
+
+func init() {
+	modules.Register("pkgprint", func() interface{} {
+		return new(Runner)
+	})
+}
+
+type FPResult struct {
+	Name    string       `json:"name"`
+	Matches []MatchGroup `json:"matches"`
+}
+
+type MatchGroup struct {
+	Root    string       `json:"root"`
+	Entries []MatchEntry `json:"entries"`
+}
+
+type MatchEntry struct {
+	Match string `json:"match"`
+}
+
+func executeTemplate(tname string, depth int) (FPResult, error) {
+	var (
+		res FPResult
+		err error
+	)
+	fp := getTemplateFingerprint(tname)
+	if fp == nil {
+		return res, fmt.Errorf("invalid template name specified")
+	}
+	res.Name = tname
+	s := NewSimpleFileLocator()
+	s.maxDepth = depth
+	s.Locate(fp.filename, fp.isRegexp)
+	for _, x := range s.matches {
+		// If an error occurs here, just ignore it and keep going.
+		m, _ := FileContentCheck(x, fp.contentMatch)
+		if len(m) == 0 {
+			continue
+		}
+		for _, i := range m {
+			// The module requires a substring match in the
+			// template, so we only process entries that have
+			// resulted in substrings being returned.
+			if len(i) < 2 {
+				continue
+			}
+			newmatch := MatchGroup{}
+			newmatch.Root = x
+			for j := 1; j < len(i); j++ {
+				nme := MatchEntry{}
+				nme.Match, err = fp.transform(i[j])
+				if err != nil {
+					continue
+				}
+				newmatch.Entries = append(newmatch.Entries, nme)
+			}
+			res.Matches = append(res.Matches, newmatch)
+		}
+	}
+	return res, nil
+}
+
+// Given a file, identify any lines in the file that match the supplied
+// regular expression. Will return a slice of string slices. If the
+// supplied regular expression contains substring matches, each string
+// slice will contain the full line matched, and any substrings, otherwise
+// the slice will only contain the line matched.
+func FileContentCheck(path string, regex string) ([][]string, error) {
+	re, err := regexp.Compile(regex)
+	if err != nil {
+		return nil, err
+	}
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		fd.Close()
+	}()
+
+	rdr := bufio.NewReader(fd)
+	ret := make([][]string, 0)
+	for {
+		ln, err := rdr.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return nil, err
+			}
+		}
+		mtch := re.FindStringSubmatch(ln)
+		if len(mtch) > 0 {
+			newmatch := make([]string, 0)
+			newmatch = append(newmatch, mtch[0])
+			for i := 1; i < len(mtch); i++ {
+				newmatch = append(newmatch, mtch[i])
+			}
+			ret = append(ret, newmatch)
+		}
+	}
+
+	if len(ret) == 0 {
+		return nil, nil
+	}
+	return ret, nil
+}
+
+type SimpleFileLocator struct {
+	executed bool
+	root     string
+	curDepth int
+	maxDepth int
+	matches  []string
+}
+
+func NewSimpleFileLocator() (ret SimpleFileLocator) {
+	ret.root = "/"
+	ret.maxDepth = 10
+	ret.matches = make([]string, 0)
+	return ret
+}
+
+func (s *SimpleFileLocator) Locate(target string, useRegexp bool) error {
+	if s.executed {
+		return fmt.Errorf("locator has already been executed")
+	}
+	s.executed = true
+	return s.locateInner(target, useRegexp, "")
+}
+
+func (s *SimpleFileLocator) locateInner(target string, useRegexp bool, path string) error {
+	var (
+		spath string
+		re    *regexp.Regexp
+		err   error
+	)
+
+	// If processing this directory would result in us exceeding the
+	// specified search depth, just ignore it.
+	if (s.curDepth + 1) > s.maxDepth {
+		return nil
+	}
+
+	if useRegexp {
+		re, err = regexp.Compile(target)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.curDepth++
+	defer func() {
+		s.curDepth--
+	}()
+
+	if path == "" {
+		spath = s.root
+	} else {
+		spath = path
+	}
+	dirents, err := ioutil.ReadDir(spath)
+	if err != nil {
+		// If we encounter an error while reading a directory, just
+		// ignore it and keep going until we are finished.
+		return nil
+	}
+	for _, x := range dirents {
+		fname := filepath.Join(spath, x.Name())
+		if x.IsDir() {
+			s.locateInner(target, useRegexp, fname)
+		} else if x.Mode().IsRegular() {
+			if !useRegexp {
+				if x.Name() == target {
+					s.matches = append(s.matches, fname)
+				}
+			} else {
+				if re.MatchString(x.Name()) {
+					s.matches = append(s.matches, fname)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func buildResults(fpres FPResult, r *modules.Result) (buf []byte, err error) {
+	r.Success = true
+	if len(fpres.Matches) > 0 {
+		r.FoundAnything = true
+	}
+	r.Elements = fpres
+	buf, err = json.Marshal(r)
+	return
+}
+
+type Runner struct {
+	Parameters Parameters
+	Results    modules.Result
+}
+
+func (r Runner) Run(in io.Reader) (resStr string) {
+	defer func() {
+		if e := recover(); e != nil {
+			r.Results.Errors = append(r.Results.Errors, fmt.Sprintf("%v", e))
+			r.Results.Success = false
+			err, _ := json.Marshal(r.Results)
+			resStr = string(err)
+			return
+		}
+	}()
+
+	runtime.GOMAXPROCS(1)
+
+	err := modules.ReadInputParameters(in, &r.Parameters)
+	if err != nil {
+		panic(err)
+	}
+
+	err = r.ValidateParameters()
+	if err != nil {
+		panic(err)
+	}
+
+	if r.Parameters.TemplateMode {
+		fpres, err := executeTemplate(r.Parameters.TemplateParams.Name, r.Parameters.SearchDepth)
+		if err != nil {
+			panic(err)
+		}
+		buf, err := buildResults(fpres, &r.Results)
+		if err != nil {
+			panic(err)
+		}
+		resStr = string(buf)
+		return
+	}
+
+	panic("no function specified")
+	return
+}
+
+func (r Runner) ValidateParameters() (err error) {
+	p := r.Parameters
+	if !p.TemplateMode {
+		return fmt.Errorf("currently template mode must be enabled")
+	}
+
+	// If template mode is in use, make sure a valid template has been
+	// specified.
+	if fp := getTemplateFingerprint(p.TemplateParams.Name); fp == nil {
+		return fmt.Errorf("invalid template %v", p.TemplateParams.Name)
+	}
+
+	if p.SearchDepth <= 0 {
+		return fmt.Errorf("invalid search depth")
+	}
+
+	return
+}
+
+type Parameters struct {
+	// Enable or disable template mode in the module. When using template
+	// mode, hardcoded fingerprints are used. In the future, this will
+	// support being set to false to allow the client to supply more
+	// advanced parameters allowing for more flexible scanning.
+	//
+	// To do this we need to figure out a way to be able to specify
+	// flexible fingerprints from the mig command line side, but prevent
+	// the use of fingerprints that could return data from more sensitive
+	// areas of the file system (e.g., /etc/shadow, etc).
+	TemplateMode   bool           `json:"templatemode"`
+	TemplateParams TemplateParams `json:"template"`
+
+	SearchDepth int `json:"depth"`
+}
+
+type TemplateParams struct {
+	Name string `json:"name"`
+}
+
+func newParameters() *Parameters {
+	return &Parameters{SearchDepth: 10}
+}
+
+func (r Runner) PrintResults(result modules.Result, foundOnly bool) (prints []string, err error) {
+	var elem FPResult
+
+	err = result.GetElements(&elem)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, x := range elem.Matches {
+		for _, y := range x.Entries {
+			resStr := fmt.Sprintf("pkgprint name=%v root=%v entry=%v", elem.Name, x.Root, y.Match)
+			prints = append(prints, resStr)
+		}
+	}
+	if !foundOnly {
+		for _, we := range result.Errors {
+			prints = append(prints, we)
+		}
+	}
+
+	return
+}

--- a/src/mig/modules/pkgprint/pkgprint.go
+++ b/src/mig/modules/pkgprint/pkgprint.go
@@ -38,7 +38,7 @@ type MatchEntry struct {
 	Match string `json:"match"`
 }
 
-func executeTemplate(tname string, depth int) (FPResult, error) {
+func executeTemplate(tname string, depth int, root string) (FPResult, error) {
 	var (
 		res FPResult
 		err error
@@ -50,6 +50,9 @@ func executeTemplate(tname string, depth int) (FPResult, error) {
 	res.Name = tname
 	s := NewSimpleFileLocator()
 	s.maxDepth = depth
+	if root != "/" {
+		s.root = root
+	}
 	s.Locate(fp.filename, fp.isRegexp)
 	for _, x := range s.matches {
 		// If an error occurs here, just ignore it and keep going.
@@ -243,7 +246,7 @@ func (r Runner) Run(in io.Reader) (resStr string) {
 	}
 
 	if r.Parameters.TemplateMode {
-		fpres, err := executeTemplate(r.Parameters.TemplateParams.Name, r.Parameters.SearchDepth)
+		fpres, err := executeTemplate(r.Parameters.TemplateParams.Name, r.Parameters.SearchDepth, r.Parameters.SearchRoot)
 		if err != nil {
 			panic(err)
 		}
@@ -291,7 +294,8 @@ type Parameters struct {
 	TemplateMode   bool           `json:"templatemode"`
 	TemplateParams TemplateParams `json:"template"`
 
-	SearchDepth int `json:"depth"`
+	SearchDepth int    `json:"depth"`
+	SearchRoot  string `json:"root"`
 }
 
 type TemplateParams struct {

--- a/src/mig/modules/pkgprint/pkgprint_test.go
+++ b/src/mig/modules/pkgprint/pkgprint_test.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+package pkgprint
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "pkgprint")
+}

--- a/src/mig/modules/pkgprint/pkgprint_test.go
+++ b/src/mig/modules/pkgprint/pkgprint_test.go
@@ -5,6 +5,11 @@
 // Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
 package pkgprint
 
+import (
+	"mig/testutil"
+	"testing"
+)
+
 func TestRegistration(t *testing.T) {
 	testutil.CheckModuleRegistration(t, "pkgprint")
 }

--- a/src/mig/modules/pkgprint/templates.go
+++ b/src/mig/modules/pkgprint/templates.go
@@ -21,6 +21,7 @@ type fingerprint struct {
 	pathFilter   string
 	contentMatch string
 	transform    func(string) (string, error)
+	forceRoot    string
 }
 
 var templates = []ppTemplate{
@@ -30,6 +31,7 @@ var templates = []ppTemplate{
 		"",
 		".*wgVersion = (\\S+)",
 		transformNull,
+		"",
 	}},
 	{"django", fingerprint{
 		"__init__.py",
@@ -37,6 +39,15 @@ var templates = []ppTemplate{
 		"django",
 		"^VERSION = (\\S+, \\S+, \\S+, \\S+, \\S+)",
 		transformDjango,
+		"",
+	}},
+	{"linuxkernel", fingerprint{
+		"version",
+		false,
+		"",
+		"^(Linux version.*)",
+		transformNull,
+		"/proc",
 	}},
 }
 

--- a/src/mig/modules/pkgprint/templates.go
+++ b/src/mig/modules/pkgprint/templates.go
@@ -49,6 +49,14 @@ var templates = []ppTemplate{
 		transformNull,
 		"/proc",
 	}},
+	{"linuxmodules", fingerprint{
+		"modules",
+		false,
+		"",
+		"^(\\S+)",
+		transformNull,
+		"/proc",
+	}},
 	{"pythonegg", fingerprint{
 		"PKG-INFO",
 		false,

--- a/src/mig/modules/pkgprint/templates.go
+++ b/src/mig/modules/pkgprint/templates.go
@@ -49,6 +49,14 @@ var templates = []ppTemplate{
 		transformNull,
 		"/proc",
 	}},
+	{"pythonegg", fingerprint{
+		"PKG-INFO",
+		false,
+		"egg-info",
+		"^Version: (\\S+)",
+		transformNull,
+		"",
+	}},
 }
 
 func getTemplateFingerprint(name string) *fingerprint {

--- a/src/mig/modules/pkgprint/templates.go
+++ b/src/mig/modules/pkgprint/templates.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+package pkgprint
+
+type ppTemplate struct {
+	name        string
+	fingerprint fingerprint
+}
+
+type fingerprint struct {
+	filename     string
+	isRegexp     bool
+	pathFilter   string
+	contentMatch string
+	transform    func(string) (string, error)
+}
+
+var templates = []ppTemplate{
+	{"mediawiki", fingerprint{
+		"DefaultSettings.php",
+		false,
+		"",
+		".*wgVersion = (\\S+)",
+		transformNull,
+	}},
+}
+
+func getTemplateFingerprint(name string) *fingerprint {
+	for x := range templates {
+		if templates[x].name == name {
+			return &templates[x].fingerprint
+		}
+	}
+	return nil
+}
+
+func transformNull(in string) (string, error) {
+	return in, nil
+}


### PR DESCRIPTION
This is a new module for MIG that locates information from the file system using data fingerprints. As an example, the module can return version information for existing web framework versions, running kernel versions, installed Python packages, etc.

This initial version uses templates that are hardcoded into the module itself. I think it would be useful in the future to support more dynamic fingerprints that can be supplied from the command line side, but this is hard to do to avoid returning sensitive information from the device, so it's something we would need to think about.

I also implemented a simple file finder and content scanner. I initially looked at using functionality from the file module. But, the path walking functions are deeply tied into the module Runner struct and other parts of the file module itself. As an end result it seemed simpler to just make a small path traversal function. The way it's been added here, it's not tied to any MIG module functionality so it's usable by other modules that may need it as well.