### PR TITLE
Improve the way version numbers are managed, fixes 1207709

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ LDFLAGS		:=
 GOOPTS		:=
 GO 			:= GOOS=$(OS) GOARCH=$(ARCH) GO15VENDOREXPERIMENT=1 go
 GOGETTER	:= GOPATH=$(shell pwd)/.tmpdeps go get -d
-GOLDFLAGS	:= -ldflags "-X main.version=$(BUILDREV)"
+GOLDFLAGS	:= -ldflags "-X mig.ninja/mig.Version=$(BUILDREV)"
 GOCFLAGS	:=
 MKDIR		:= mkdir
 INSTALL		:= install

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 BUILDENV	:= dev
+BUILDREL 	:= 0
 ifeq ($(OS),windows)
-	# on windows, the version is year.month.date
-	BUILDREV := $(shell date +%y).$(shell date +%m).$(shell date +%d)
+	# on windows, the version is year.month.date.release
+	BUILDREV := $(shell date +%y).$(shell date +%m).$(shell date +%d).$(BUILDREL)
 	BINSUFFIX := ".exe"
 else
-	# on *nix, the version is yearmonthdate+lastcommit.env
-	BUILDREV := $(shell date +%Y%m%d)+$(shell git log --pretty=format:'%h' -n 1).$(BUILDENV)
+	# on *nix, the version is yearmonthdate.release+lastcommit.env
+	BUILDREV := $(shell date +%Y%m%d)-$(BUILDREL).$(shell git log --pretty=format:'%h' -n 1).$(BUILDENV)
 	BINSUFFIX := ""
 endif
 

--- a/client/mig-action-generator/generator.go
+++ b/client/mig-action-generator/generator.go
@@ -10,15 +10,13 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"mig.ninja/mig"
-	"mig.ninja/mig/client"
 	"net/url"
 	"os"
 	"time"
-)
 
-// build version
-var version string
+	"mig.ninja/mig"
+	"mig.ninja/mig/client"
+)
 
 func main() {
 	var err error
@@ -52,7 +50,7 @@ func main() {
 	flag.Parse()
 
 	if *showversion {
-		fmt.Println(version)
+		fmt.Println(mig.Version)
 		os.Exit(0)
 	}
 
@@ -65,7 +63,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	cli, err := client.NewClient(conf, "generator-"+version)
+	cli, err := client.NewClient(conf, "generator-"+mig.Version)
 	if err != nil {
 		panic(err)
 	}

--- a/client/mig-action-verifier/verifier.go
+++ b/client/mig-action-verifier/verifier.go
@@ -8,9 +8,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"mig.ninja/mig"
 	"mig.ninja/mig/client"
-	"os"
 )
 
 func main() {
@@ -33,7 +34,13 @@ func main() {
 	var actionfile = flag.String("a", "/path/to/action", "Load action from file")
 	var commandfile = flag.String("c", "/path/to/command", "Load command from file")
 	var config = flag.String("conf", homedir+"/.migrc", "Load configuration from file")
+	var showversion = flag.Bool("V", false, "Show build version and exit")
 	flag.Parse()
+
+	if *showversion {
+		fmt.Println(mig.Version)
+		os.Exit(0)
+	}
 
 	conf, err := client.ReadConfiguration(*config)
 	if err != nil {

--- a/client/mig-console/console.go
+++ b/client/mig-console/console.go
@@ -22,9 +22,6 @@ import (
 	"mig.ninja/mig/client"
 )
 
-// build version
-var version string
-
 func main() {
 	var err error
 	defer func() {
@@ -41,7 +38,7 @@ func main() {
 	flag.Parse()
 
 	if *showversion {
-		fmt.Println(version)
+		fmt.Println(mig.Version)
 		os.Exit(0)
 	}
 
@@ -74,7 +71,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	cli, err := client.NewClient(conf, "console-"+version)
+	cli, err := client.NewClient(conf, "console-"+mig.Version)
 	if err != nil {
 		panic(err)
 	}

--- a/client/mig/main.go
+++ b/client/mig/main.go
@@ -19,9 +19,6 @@ import (
 	"mig.ninja/mig/modules"
 )
 
-// build version
-var version string
-
 func usage() {
 	fmt.Printf(`%s - Mozilla InvestiGator command line client
 usage: %s <module> <global options> <module parameters>
@@ -49,6 +46,7 @@ usage: %s <module> <global options> <module parameters>
 		* agents operated by IT: -t "tags#>>'{operator}'='IT'"
 		* run on local system:	 -t local
 -v		verbose output, includes debug information and raw queries
+-V		print version
 
 Progress information is sent to stderr, silence it with "2>/dev/null".
 Results are sent to stdout, redirect them with "1>/path/to/file".
@@ -77,7 +75,7 @@ func main() {
 		a                                              mig.Action
 		migrc, show, render, target, expiration, afile string
 		printAndExit                                   bool
-		verbose                                        bool
+		verbose, showversion                           bool
 		modargs                                        []string
 		run                                            interface{}
 	)
@@ -97,6 +95,7 @@ func main() {
 	fs.StringVar(&expiration, "e", "300s", "expiration")
 	fs.StringVar(&afile, "i", "/path/to/file", "Load action from file")
 	fs.BoolVar(&verbose, "v", false, "Enable verbose output")
+	fs.BoolVar(&showversion, "V", false, "Show version")
 
 	// if first argument is missing, or is help, print help
 	// otherwise, pass the remainder of the arguments to the module for parsing
@@ -105,8 +104,8 @@ func main() {
 		usage()
 	}
 
-	if len(os.Args) < 2 || os.Args[1] == "-V" {
-		fmt.Println(version)
+	if showversion || (len(os.Args) > 1 && (os.Args[1] == "-V" || os.Args[1] == "version")) {
+		fmt.Println(mig.Version)
 		os.Exit(0)
 	}
 
@@ -234,7 +233,7 @@ readytolaunch:
 	if err != nil {
 		panic(err)
 	}
-	cli, err = client.NewClient(conf, "cmd-"+version)
+	cli, err = client.NewClient(conf, "cmd-"+mig.Version)
 	if err != nil {
 		panic(err)
 	}

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -10,21 +10,19 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/jvehent/service-go"
-	"github.com/streadway/amqp"
 	"io/ioutil"
-	"mig.ninja/mig"
-	"mig.ninja/mig/modules"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
-)
 
-// build version
-var version string
+	"github.com/jvehent/service-go"
+	"github.com/streadway/amqp"
+	"mig.ninja/mig"
+	"mig.ninja/mig/modules"
+)
 
 // publication lock is used to prevent publication when the channels are not
 // available, like during a shutdown
@@ -73,7 +71,7 @@ func main() {
 	flag.Parse()
 
 	if *showversion {
-		fmt.Println(version)
+		fmt.Println(mig.Version)
 		os.Exit(0)
 	}
 
@@ -205,7 +203,7 @@ func runAgentCheckin(foreground, upgrading, debug bool) (err error) {
 		fmt.Fprintf(os.Stderr, "Failed to start agent routines: '%v'", err)
 		os.Exit(0)
 	}
-	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Mozilla InvestiGator version %s: started agent %s in checkin mode", version, ctx.Agent.Hostname)}
+	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Mozilla InvestiGator version %s: started agent %s in checkin mode", mig.Version, ctx.Agent.Hostname)}
 
 	// The loop below retrieves messages from the relay. If no message is available,
 	// it will timeout and break out of the loop after 10 seconds, causing the agent to exit
@@ -279,7 +277,7 @@ func runAgent(foreground, upgrading, debug bool) (err error) {
 		panic(err)
 	}
 
-	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Mozilla InvestiGator version %s: started agent %s", version, ctx.Agent.Hostname)}
+	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Mozilla InvestiGator version %s: started agent %s", mig.Version, ctx.Agent.Hostname)}
 
 	// The agent blocks here until a termination order is received
 	// The order is then evaluated to decide if a new agent must be respawned, or the agent
@@ -669,7 +667,7 @@ func heartbeat(ctx Context) (err error) {
 	HeartBeat := mig.Agent{
 		Name:      ctx.Agent.Hostname,
 		Mode:      ctx.Agent.Mode,
-		Version:   version,
+		Version:   mig.Version,
 		PID:       os.Getpid(),
 		QueueLoc:  ctx.Agent.QueueLoc,
 		StartTime: time.Now(),

--- a/mig-api/api.go
+++ b/mig-api/api.go
@@ -8,18 +8,16 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/gorilla/context"
-	"github.com/gorilla/mux"
-	"github.com/jvehent/cljs"
-	"mig.ninja/mig"
 	"net/http"
 	"os"
 	"runtime"
 	"strings"
-)
 
-// build version
-var version string
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"github.com/jvehent/cljs"
+	"mig.ninja/mig"
+)
 
 var ctx Context
 
@@ -35,7 +33,7 @@ func main() {
 	flag.Parse()
 
 	if *showversion {
-		fmt.Println(version)
+		fmt.Println(mig.Version)
 		os.Exit(0)
 	}
 

--- a/mig-runner/main.go
+++ b/mig-runner/main.go
@@ -9,12 +9,13 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"mig.ninja/mig"
 	"os"
 	"os/signal"
 	"path"
 	"sync"
 	"time"
+
+	"mig.ninja/mig"
 )
 
 var ctx Context
@@ -24,7 +25,13 @@ func main() {
 	var err error
 
 	var config = flag.String("c", "/etc/mig/runner.cfg", "Load configuration from file")
+	var showversion = flag.Bool("V", false, "Show build version and exit")
 	flag.Parse()
+
+	if *showversion {
+		fmt.Println(mig.Version)
+		os.Exit(0)
+	}
 
 	ctx, err = initContext(*config)
 	if err != nil {

--- a/mig-scheduler/scheduler.go
+++ b/mig-scheduler/scheduler.go
@@ -19,16 +19,19 @@ import (
 	"mig.ninja/mig/pgp"
 )
 
-// build version
-var version string
-
 func main() {
 	cpus := runtime.NumCPU()
 	runtime.GOMAXPROCS(cpus * 2)
 
 	// command line options
 	var config = flag.String("c", "/etc/mig/scheduler.cfg", "Load configuration from file")
+	var showversion = flag.Bool("V", false, "Show build version and exit")
 	flag.Parse()
+
+	if *showversion {
+		fmt.Println(mig.Version)
+		os.Exit(0)
+	}
 
 	// The context initialization takes care of parsing the configuration,
 	// and creating connections to database, message broker, syslog, ...

--- a/modules/file/paramscreator.go
+++ b/modules/file/paramscreator.go
@@ -83,7 +83,7 @@ Module documentation is at http://mig.mozilla.org/doc/module_file.html
 Cheatsheet and examples are at http://mig.mozilla.org/doc/cheatsheet.rst.html
 `, dash, dash, dash, dash, dash, dash, dash, dash, dash, dash, dash,
 		dash, dash, dash, dash, dash, dash, dash, dash, dash,
-		dash, dash, dash, dash, dash, dash, dash, dash)
+		dash, dash, dash, dash, dash, dash)
 
 	return
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
+
+package mig /* import "mig.ninja/mig" */
+
+var Version string = "20150924+637dcd7"

--- a/version.go
+++ b/version.go
@@ -6,4 +6,4 @@
 
 package mig /* import "mig.ninja/mig" */
 
-var Version string = "20150924+637dcd7"
+var Version string = "20150924-0.76f33f2"

--- a/workers/mig-worker-agent-intel/main.go
+++ b/workers/mig-worker-agent-intel/main.go
@@ -6,16 +6,17 @@
 package main
 
 import (
-	"gopkg.in/gcfg.v1"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/jvehent/gozdef"
-	"mig.ninja/mig"
-	"mig.ninja/mig/workers"
 	"os"
 	"os/exec"
 	"regexp"
+
+	"github.com/jvehent/gozdef"
+	"gopkg.in/gcfg.v1"
+	"mig.ninja/mig"
+	"mig.ninja/mig/workers"
 )
 
 const workerName = "agent_intel"
@@ -42,7 +43,12 @@ func main() {
 		flag.PrintDefaults()
 	}
 	var configPath = flag.String("c", "/etc/mig/agent-intel-worker.cfg", "Load configuration from file")
+	var showversion = flag.Bool("V", false, "Show build version and exit")
 	flag.Parse()
+	if *showversion {
+		fmt.Println(mig.Version)
+		os.Exit(0)
+	}
 	err = gcfg.ReadFileInto(&conf, *configPath)
 	if err != nil {
 		panic(err)

--- a/workers/mig-worker-agent-verif/main.go
+++ b/workers/mig-worker-agent-verif/main.go
@@ -6,12 +6,13 @@
 package main
 
 import (
-	"gopkg.in/gcfg.v1"
 	"flag"
 	"fmt"
+	"os"
+
+	"gopkg.in/gcfg.v1"
 	"mig.ninja/mig"
 	"mig.ninja/mig/workers"
-	"os"
 )
 
 const workerName = "agent_verif"
@@ -31,7 +32,13 @@ func main() {
 		flag.PrintDefaults()
 	}
 	var configPath = flag.String("c", "/etc/mig/agent-verif-worker.cfg", "Load configuration from file")
+	var showversion = flag.Bool("V", false, "Show build version and exit")
 	flag.Parse()
+	if *showversion {
+		fmt.Println(mig.Version)
+		os.Exit(0)
+	}
+
 	err = gcfg.ReadFileInto(&conf, *configPath)
 	if err != nil {
 		panic(err)

--- a/workers/mig-worker-compliance-item/main.go
+++ b/workers/mig-worker-compliance-item/main.go
@@ -6,19 +6,20 @@
 package main
 
 import (
-	"gopkg.in/gcfg.v1"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/jvehent/gozdef"
-	"mig.ninja/mig"
-	"mig.ninja/mig/modules"
-	"mig.ninja/mig/modules/file"
-	"mig.ninja/mig/workers"
 	"os"
 	"os/exec"
 	"regexp"
 	"time"
+
+	"github.com/jvehent/gozdef"
+	"gopkg.in/gcfg.v1"
+	"mig.ninja/mig"
+	"mig.ninja/mig/modules"
+	"mig.ninja/mig/modules/file"
+	"mig.ninja/mig/workers"
 )
 
 const workerName = "compliance_item"
@@ -46,7 +47,13 @@ func main() {
 		flag.PrintDefaults()
 	}
 	var configPath = flag.String("c", "/etc/mig/compliance-item-worker.cfg", "Load configuration from file")
+	var showversion = flag.Bool("V", false, "Show build version and exit")
 	flag.Parse()
+	if *showversion {
+		fmt.Println(mig.Version)
+		os.Exit(0)
+	}
+
 	err = gcfg.ReadFileInto(&conf, *configPath)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
In [bug 1207709](https://bugzilla.mozilla.org/show_bug.cgi?id=1207709), we noted that the `version` string isn't set when installing binaries using `go get`. This patch sets a base version string the MIG package, which is modified when binaries are built using the Makefile. The trade-off is that we'll need to update the base version string on a regular basis.

```
$ make
$ for bin in $(ls bin/linux/amd64); do echo -en "$bin: "; ./bin/linux/amd64/$bin -V; done|column -t
mig:                             20150924+11e33fc.dev
mig-action-generator:            20150924+11e33fc.dev
mig-action-verifier:             20150924+11e33fc.dev
mig-agent-20150924+11e33fc.dev:  20150924+11e33fc.dev
mig-agent-latest:                20150924+11e33fc.dev
mig-api:                         20150924+11e33fc.dev
mig-console:                     20150924+11e33fc.dev
mig-runner:                      20150924+11e33fc.dev
mig-scheduler:                   20150924+11e33fc.dev
mig-worker-agent-intel:          20150924+11e33fc.dev
mig-worker-compliance-item:      20150924+11e33fc.dev
```

@ameihm0912 : r?