### PR TITLE
[minor] honor os proxy environment variables in client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -93,6 +93,7 @@ func NewClient(conf Configuration, version string) (cli Client, err error) {
 			},
 			InsecureSkipVerify: conf.API.SkipVerifyCert,
 		},
+		Proxy: http.ProxyFromEnvironment,
 	}
 	cli.API = &http.Client{Transport: tr}
 	// if the env variable to the gpg agent socket isn't set, try to


### PR DESCRIPTION
When building client transport, include OS related proxy configuration so client can make use of it