### PR TITLE
[minor] add optional hashing for file module results

### DIFF
--- a/modules/file/doc.rst
+++ b/modules/file/doc.rst
@@ -218,6 +218,11 @@ Several options can be applied to a search:
   single file search, you should probably consider breaking it down into smaller
   searches, or running the search locally instead of through MIG.
 
+* **returnsha256** instructs the agent to return the SHA256 hash for any
+  matched files. The client will display the hash with the file information
+  in the result. As an example, this option can be used to do basic file
+  integrity monitoring across actions.
+
 Search algorithm
 ----------------
 

--- a/modules/file/file.go
+++ b/modules/file/file.go
@@ -95,14 +95,14 @@ type search struct {
 }
 
 type options struct {
-	MaxDepth   float64  `json:"maxdepth"`
-	RemoteFS   bool     `json:"remotefs,omitempty"`
-	MatchAll   bool     `json:"matchall"`
-	Macroal    bool     `json:"macroal"`
-	Mismatch   []string `json:"mismatch"`
-	MatchLimit float64  `json:"matchlimit"`
-	Debug      string   `json:"debug,omitempty"`
-	Hash       bool     `json:"hash"`
+	MaxDepth     float64  `json:"maxdepth"`
+	RemoteFS     bool     `json:"remotefs,omitempty"`
+	MatchAll     bool     `json:"matchall"`
+	Macroal      bool     `json:"macroal"`
+	Mismatch     []string `json:"mismatch"`
+	MatchLimit   float64  `json:"matchlimit"`
+	Debug        string   `json:"debug,omitempty"`
+	ReturnSHA256 bool     `json:"returnsha256,omitempty"`
 }
 
 type checkType uint64
@@ -1533,7 +1533,7 @@ type fileinfo struct {
 	Size   float64 `json:"size"`
 	Mode   string  `json:"mode"`
 	Mtime  string  `json:"lastmodified"`
-	SHA256 string  `json:"sha256"`
+	SHA256 string  `json:"sha256,omitempty"`
 }
 
 // newResults allocates a Results structure
@@ -1607,7 +1607,7 @@ func (r *run) buildResults(t0 time.Time) (resStr string, err error) {
 					mf.FileInfo.Size = float64(fi.Size())
 					mf.FileInfo.Mode = fi.Mode().String()
 					mf.FileInfo.Mtime = fi.ModTime().UTC().String()
-					if search.Options.Hash {
+					if search.Options.ReturnSHA256 {
 						mf.FileInfo.SHA256, err = getHash(mf.File, checkSHA256)
 						if err != nil {
 							panic(err)
@@ -1746,7 +1746,7 @@ func (r *run) PrintResults(result modules.Result, foundOnly bool) (prints []stri
 				out = fmt.Sprintf("%s [lastmodified:%s, mode:%s, size:%.0f",
 					mf.File, mf.FileInfo.Mtime, mf.FileInfo.Mode, mf.FileInfo.Size)
 				if mf.FileInfo.SHA256 != "" {
-					out += fmt.Sprintf(", hash:%s", strings.ToLower(mf.FileInfo.SHA256))
+					out += fmt.Sprintf(", sha256:%s", strings.ToLower(mf.FileInfo.SHA256))
 				}
 				out += fmt.Sprintf("] in search '%s'", label)
 			}

--- a/modules/file/paramscreator.go
+++ b/modules/file/paramscreator.go
@@ -79,13 +79,13 @@ Options
 			  the default limit is set to 1000. search will stop once the limit
 			  is reached.
 %sreturnsha256		- include sha256 hash for matched files.
-			  ex: -returnsha256
+			  ex: %sreturnsha256
 
 Module documentation is at http://mig.mozilla.org/doc/module_file.html
 Cheatsheet and examples are at http://mig.mozilla.org/doc/cheatsheet.rst.html
 `, dash, dash, dash, dash, dash, dash, dash, dash, dash, dash, dash,
 		dash, dash, dash, dash, dash, dash, dash, dash, dash,
-		dash, dash, dash, dash, dash, dash, dash)
+		dash, dash, dash, dash, dash, dash, dash, dash)
 
 	return
 }

--- a/modules/file/paramscreator.go
+++ b/modules/file/paramscreator.go
@@ -78,12 +78,14 @@ Options
 %smatchlimit <int>	- limit the number of files that can be matched by a search.
 			  the default limit is set to 1000. search will stop once the limit
 			  is reached.
+%shash			- include sha256 hash for matched files.
+			  ex: -hash
 
 Module documentation is at http://mig.mozilla.org/doc/module_file.html
 Cheatsheet and examples are at http://mig.mozilla.org/doc/cheatsheet.rst.html
 `, dash, dash, dash, dash, dash, dash, dash, dash, dash, dash, dash,
 		dash, dash, dash, dash, dash, dash, dash, dash, dash,
-		dash, dash, dash, dash, dash, dash)
+		dash, dash, dash, dash, dash, dash, dash)
 
 	return
 }
@@ -344,6 +346,12 @@ func (r *run) ParamsCreator() (interface{}, error) {
 					continue
 				}
 				search.Options.MatchAll = false
+			case "hash":
+				if checkValue != "" {
+					fmt.Println("This option doesn't take arguments, try again")
+					continue
+				}
+				search.Options.Hash = true
 			case "macroal":
 				if checkValue != "" {
 					fmt.Println("This option doesn't take arguments, try again")
@@ -394,9 +402,9 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 		err error
 		paths, names, sizes, modes, mtimes, contents, md5s, sha1s, sha256s,
 		sha384s, sha512s, sha3_224s, sha3_256s, sha3_384s, sha3_512s, mismatch flagParam
-		maxdepth, matchlimit                 float64
-		matchall, matchany, macroal, verbose bool
-		fs                                   flag.FlagSet
+		maxdepth, matchlimit                       float64
+		hash, matchall, matchany, macroal, verbose bool
+		fs                                         flag.FlagSet
 	)
 	if len(args) < 1 || args[0] == "" || args[0] == "help" {
 		printHelp(true)
@@ -425,6 +433,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	fs.BoolVar(&matchany, "matchany", false, "see help")
 	fs.BoolVar(&macroal, "macroal", false, "see help")
 	fs.BoolVar(&debug, "verbose", false, "see help")
+	fs.BoolVar(&hash, "hash", false, "see help")
 	err = fs.Parse(args)
 	if err != nil {
 		return nil, err
@@ -450,6 +459,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	s.Options.Macroal = macroal
 	s.Options.Mismatch = mismatch
 	s.Options.MatchAll = matchall
+	s.Options.Hash = hash
 	if matchany {
 		s.Options.MatchAll = false
 	}

--- a/modules/file/paramscreator.go
+++ b/modules/file/paramscreator.go
@@ -78,8 +78,8 @@ Options
 %smatchlimit <int>	- limit the number of files that can be matched by a search.
 			  the default limit is set to 1000. search will stop once the limit
 			  is reached.
-%shash			- include sha256 hash for matched files.
-			  ex: -hash
+%sreturnsha256		- include sha256 hash for matched files.
+			  ex: -returnsha256
 
 Module documentation is at http://mig.mozilla.org/doc/module_file.html
 Cheatsheet and examples are at http://mig.mozilla.org/doc/cheatsheet.rst.html
@@ -346,12 +346,12 @@ func (r *run) ParamsCreator() (interface{}, error) {
 					continue
 				}
 				search.Options.MatchAll = false
-			case "hash":
+			case "returnsha256":
 				if checkValue != "" {
 					fmt.Println("This option doesn't take arguments, try again")
 					continue
 				}
-				search.Options.Hash = true
+				search.Options.ReturnSHA256 = true
 			case "macroal":
 				if checkValue != "" {
 					fmt.Println("This option doesn't take arguments, try again")
@@ -402,9 +402,9 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 		err error
 		paths, names, sizes, modes, mtimes, contents, md5s, sha1s, sha256s,
 		sha384s, sha512s, sha3_224s, sha3_256s, sha3_384s, sha3_512s, mismatch flagParam
-		maxdepth, matchlimit                       float64
-		hash, matchall, matchany, macroal, verbose bool
-		fs                                         flag.FlagSet
+		maxdepth, matchlimit                               float64
+		returnsha256, matchall, matchany, macroal, verbose bool
+		fs                                                 flag.FlagSet
 	)
 	if len(args) < 1 || args[0] == "" || args[0] == "help" {
 		printHelp(true)
@@ -433,7 +433,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	fs.BoolVar(&matchany, "matchany", false, "see help")
 	fs.BoolVar(&macroal, "macroal", false, "see help")
 	fs.BoolVar(&debug, "verbose", false, "see help")
-	fs.BoolVar(&hash, "hash", false, "see help")
+	fs.BoolVar(&returnsha256, "returnsha256", false, "see help")
 	err = fs.Parse(args)
 	if err != nil {
 		return nil, err
@@ -459,7 +459,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	s.Options.Macroal = macroal
 	s.Options.Mismatch = mismatch
 	s.Options.MatchAll = matchall
-	s.Options.Hash = hash
+	s.Options.ReturnSHA256 = returnsha256
 	if matchany {
 		s.Options.MatchAll = false
 	}


### PR DESCRIPTION
If the -hash option is present, include the SHA256 sum of the matched
file as part of the file info.

This is intended to be used for example with broad searches as a source for integrity monitoring across multiple runs.