### PR TITLE
[client] better description on gpg key not found

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -217,7 +217,7 @@ func MakeConfiguration(file string) (err error) {
 		}
 	}
 	if cfg.GPG.KeyID == "" {
-		panic("no suitable key found")
+		panic("no suitable key found in " + sr.Name())
 	}
 	for {
 		fmt.Printf("what is the location of the API? (ex: https://mig.example.net/api/v1/) > ")


### PR DESCRIPTION
When the .migrc is missing, a new one can be created, and if gpg is
installed, but there is no suitable key in the secring file, it will
display an error saying "No suitable key found". This commit also adds
to the error description the file which was inspected.

This fixes issue #132.