### PR TITLE
[minor] fix permissions bug on receiveModuleResults in mig-agent

### DIFF
--- a/mig-agent/env.go
+++ b/mig-agent/env.go
@@ -9,13 +9,15 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"mig.ninja/mig"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	"mig.ninja/mig"
 )
 
+// findLocalIPs updates the given context with the IP Addresses found in the machine.
 func findLocalIPs(orig_ctx Context) (ctx Context, err error) {
 	ctx = orig_ctx
 	// grab the local ip addresses


### PR DESCRIPTION
There was an ioutil.WriteFile whose permissions were not in octal, giving
the resulting file bad permissions.

This commit also changes some of the printf formats from '%s' to %q,
which already quotes the desired variable.