### PR TITLE
[minor] panic on agent init err if foreground mode

### DIFF
--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -253,7 +253,7 @@ func runAgent(foreground, upgrading, debug bool) (err error) {
 	ctx, err = Init(foreground, upgrading)
 	if err != nil {
 		ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Init failed: '%v'", err)}.Err()
-		if debug {
+		if foreground {
 			// if in foreground mode, don't retry, just panic
 			time.Sleep(1 * time.Second)
 			panic(err)


### PR DESCRIPTION
The comment said "if in foreground mode, don't retry, just panic", but
the if condition only checked for debug, no foreground.
debug -> foreground, but you can run the mig agent in foreground without
debug mode.