### PR TITLE
Minor refactor on mig-agent startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
     - cd "$GOPATH/src/mig.ninja/mig"
     - make
     - yes | bash tools/standalone_install.sh
+    - ./bin/linux/amd64/mig-agent-latest -i actions/example_v2.json

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -78,17 +78,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *debug {
-		*foreground = true
-		LOGGINGCONF.Level = "debug"
-		LOGGINGCONF.Mode = "stdout"
-	}
-
 	if *query != "somequery" {
 		resp, err := socketQuery(SOCKET, *query)
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(10)
+			os.Exit(1)
 		}
 		fmt.Println(resp)
 		goto exit
@@ -98,7 +92,7 @@ func main() {
 		res, err := loadActionFromFile(*file, *pretty)
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(10)
+			os.Exit(1)
 		}
 		fmt.Println(res)
 		goto exit
@@ -112,6 +106,13 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stderr, "[info] Using external conf from %q\n", *config)
 	}
+
+	if *debug {
+		*foreground = true
+		LOGGINGCONF.Level = "debug"
+		LOGGINGCONF.Mode = "stdout"
+	}
+
 	// if checkin mode is set in conf, enforce the mode
 	if CHECKIN && *mode == "agent" {
 		*mode = "agent-checkin"


### PR DESCRIPTION
To make the code more easy to follow, I moved the logic for
loading/running an action from a file into it's own function
"loadActionFromFile"

Also move the "debug-mode" switch to after loading the mig configuration,
because loading the configuration overrides the LOGGINGCONF variable