### PR TITLE
[minor] detect/interrogate linux netns namespaces in netstat module

### DIFF
--- a/modules/netstat/netstat_netns_darwin.go
+++ b/modules/netstat/netstat_netns_darwin.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package netstat /* import "mig.ninja/mig/modules/netstat" */
+
+func namespacesSupported() bool {
+	return false
+}
+
+func setNamespace(fd int) (err error) {
+	return
+}
+
+func cacheNamespaces() (ret []int, err error) {
+	return
+}

--- a/modules/netstat/netstat_netns_linux.go
+++ b/modules/netstat/netstat_netns_linux.go
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package netstat /* import "mig.ninja/mig/modules/netstat" */
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"syscall"
+)
+
+var SYS_SETNS = 308
+
+func namespacesSupported() bool {
+	return true
+}
+
+func setNamespace(fd int) error {
+	defer syscall.Close(fd)
+	_, _, errno := syscall.RawSyscall(uintptr(SYS_SETNS), uintptr(fd), 0, 0)
+	if errno != 0 {
+		return fmt.Errorf("setNamespace Linux errno %v", errno)
+	}
+	return nil
+}
+
+func cacheNamespaces() ([]int, error) {
+	retfd := make([]int, 0)
+	pents, err := ioutil.ReadDir("/proc")
+	if err != nil {
+		return retfd, err
+	}
+
+	seen := make([]string, 0)
+	for _, procdir := range pents {
+		// We only want numeric PID directories
+		_, err = strconv.Atoi(procdir.Name())
+		if err != nil {
+			continue
+		}
+		nsfile := path.Join("/proc", procdir.Name(), "ns", "net")
+		fi, err := os.Lstat(nsfile)
+		if err != nil {
+			return retfd, err
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		lname, err := os.Readlink(nsfile)
+		if err != nil {
+			// Don't treat this as an error; this can be the result of a TOCTOU
+			// issue, just ignore it and move on.
+			continue
+		}
+		found := false
+		for _, check := range seen {
+			if check == lname {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+
+		fd, err := syscall.Open(nsfile, syscall.O_RDONLY, 0666)
+		if err != nil {
+			// Likewise here.
+			continue
+		}
+		seen = append(seen, lname)
+		retfd = append(retfd, fd)
+	}
+
+	return retfd, nil
+}

--- a/modules/netstat/netstat_netns_windows.go
+++ b/modules/netstat/netstat_netns_windows.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package netstat /* import "mig.ninja/mig/modules/netstat" */
+
+func namespacesSupported() bool {
+	return false
+}
+
+func setNamespace(fd int) (err error) {
+	return
+}
+
+func cacheNamespaces() (ret []int, err error) {
+	return
+}

--- a/modules/netstat/paramscreator.go
+++ b/modules/netstat/paramscreator.go
@@ -38,6 +38,9 @@ connectedip <ip|cidr>	search for connections with the given IP address or within
 
 listeningport <port>	search for an open socket on the local system listening on <port>, tcp and udp
 			example: > listeningport 443
+
+namespaces              enable active network namespace resolution and interrogate namespaces (linux)
+                        example: > namespaces
 `
 
 // ParamsCreator implements an interactive parameters creation interface, which
@@ -62,6 +65,11 @@ func (r *run) ParamsCreator() (interface{}, error) {
 		}
 		if input == "help" {
 			fmt.Printf("%s\n", help)
+			continue
+		}
+		if input == "namespaces" {
+			p.Namespaces = true
+			fmt.Printf("Enabled namespaces. Enter another parameter, or 'done' to exit.\n")
 			continue
 		}
 		arr := strings.SplitN(input, " ", 2)
@@ -130,30 +138,33 @@ func (r *run) ParamsCreator() (interface{}, error) {
 }
 
 const cmd_help string = `
--lm <regex>	search for local mac addresses that match <regex>
-		example: -lm ^8c:70:[0-9a-f]
+-lm <regex>	    search for local mac addresses that match <regex>
+		    example: -lm ^8c:70:[0-9a-f]
 
--nm <regex>	search for neighbors mac addresses that match <regex>
-		in the ARP table
-		example: -nm ^8c:70:[0-9a-f]
+-nm <regex>	    search for neighbors mac addresses that match <regex>
+		    in the ARP table
+		    example: -nm ^8c:70:[0-9a-f]
 
--li <ip|cidr>	search for IPs that match <ip|cidr> on the local interfaces
-		if a cidr is specified, return all matching addresses.
-		example: -li 10.0.0.0/8
-			 -li 2001:db8::/32
+-li <ip|cidr>	    search for IPs that match <ip|cidr> on the local interfaces
+		    if a cidr is specified, return all matching addresses.
+		    example: -li 10.0.0.0/8
+			     -li 2001:db8::/32
 
--ni <ip|cidr>	search for neighbors IPs that match <ip|cidr> in the ARP table
-		if a cidr is specified, return all matching addresses
-		example: -ni 10.1.2.3
-			 -ni fdda:5cc1:23:4::1f
+-ni <ip|cidr>	    search for neighbors IPs that match <ip|cidr> in the ARP table
+		    if a cidr is specified, return all matching addresses
+		    example: -ni 10.1.2.3
+			     -ni fdda:5cc1:23:4::1f
 
--ci <ip|cidr>	search for remote IPs connected to the system matching <ip|cidr>.
-		returns connection tuple: localip:localport remoteip:remoteport
-		example: -ci 80.70.60.0/24
-			 -ci 2001:0db8:0123:4567:89ab:cdef:1234:0/116
+-ci <ip|cidr>	    search for remote IPs connected to the system matching <ip|cidr>.
+		    returns connection tuple: localip:localport remoteip:remoteport
+		    example: -ci 80.70.60.0/24
+			     -ci 2001:0db8:0123:4567:89ab:cdef:1234:0/116
 
--lp <port>	search for a listening tcp/udp port on <port>
-		example: -lp 443
+-lp <port>	    search for a listening tcp/udp port on <port>
+		    example: -lp 443
+
+-namespaces <bool>  enable active network namespace resolution and interrogate namespaces (linux)
+                    example: -namespaces
 `
 
 // ParamsParser implements a command line parameters parser that takes a string
@@ -164,6 +175,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 		err                    error
 		lm, nm, li, ni, ci, lp flagParam
 		fs                     flag.FlagSet
+		namespaces             bool
 	)
 	if len(args) < 1 || args[0] == "" || args[0] == "help" {
 		fmt.Println(cmd_help)
@@ -176,6 +188,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	fs.Var(&ni, "ni", "see help")
 	fs.Var(&ci, "ci", "see help")
 	fs.Var(&lp, "lp", "see help")
+	fs.BoolVar(&namespaces, "namespaces", false, "see help")
 	err = fs.Parse(args)
 	if err != nil {
 		return nil, err
@@ -187,6 +200,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	p.NeighborIP = ni
 	p.ConnectedIP = ci
 	p.ListeningPort = lp
+	p.Namespaces = namespaces
 
 	r.Parameters = p
 	return p, r.ValidateParameters()


### PR DESCRIPTION
This patch adds support for network namespace switching to the netstat
module, intended for interrogating environments such as docker
environments from a privileged host running an agent.