### PR TITLE
Scheduler relay heartbeat

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -18,4 +18,7 @@ const (
 	Ev_Q_Agt_Auth_Fail = "agent.authentication.failure"
 	Ev_Q_Agt_New       = "agent.new"
 	Ev_Q_Cmd_Res       = "command.results"
+
+	// dummy queue for scheduler heartbeats to the relays
+	Ev_Q_Sched_Hb = "scheduler.heartbeat"
 )

--- a/mig-scheduler/context.go
+++ b/mig-scheduler/context.go
@@ -10,17 +10,18 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/streadway/amqp"
-	"gopkg.in/gcfg.v1"
 	"io"
 	"io/ioutil"
-	"mig.ninja/mig"
-	migdb "mig.ninja/mig/database"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/streadway/amqp"
+	"gopkg.in/gcfg.v1"
+	"mig.ninja/mig"
+	migdb "mig.ninja/mig/database"
 )
 
 // Context contains all configuration variables as well as handlers for
@@ -317,6 +318,7 @@ func initChannels(orig_ctx Context) (ctx Context, err error) {
 	ctx.Channels.CommandDone = make(chan mig.Command)
 	ctx.Channels.DetectDupAgents = make(chan string)
 	ctx.Channels.Log = make(chan mig.Log, 100000)
+	ctx.Channels.Terminate = make(chan error)
 	ctx.Channels.Log <- mig.Log{Desc: "leaving initChannels()"}.Debug()
 	return
 }

--- a/mig-scheduler/events.go
+++ b/mig-scheduler/events.go
@@ -7,9 +7,10 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/streadway/amqp"
 	"mig.ninja/mig"
-	"time"
 )
 
 // sendEvent publishes a message to the miginternal rabbitmq exchange

--- a/version.go
+++ b/version.go
@@ -6,4 +6,4 @@
 
 package mig /* import "mig.ninja/mig" */
 
-var Version string = "20150924-0.76f33f2"
+var Version string = "20151005-0.6d52906"


### PR DESCRIPTION
If RabbitMQ suffers a network partition, the scheduler will remain in a half broken state where no message can be consumed or published, but other goroutines work fine. This patch introduce a new dummy event that heartbeats the scheduler and terminates it if the publication of the heartbeat fails. The hearbeat is a normal event that expires in rabbitmq after 100 minutes, like any other event. It is published to a queue that could eventually be consumed for monitoring.

r? @ameihm0912 