### PR TITLE
[medium] Unify hash selection under sha2/sha3; fixes #155

### DIFF
--- a/actions/linux-backdoor-kanada-team-binaries.json
+++ b/actions/linux-backdoor-kanada-team-binaries.json
@@ -20,7 +20,7 @@
                         "paths": [
                             "/bin"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "adbee847c12c73605ff657e668c8096df138f824eb542027a10c0b5c07619c8d",
                             "7c9816b5f1b840eb8c5ecfc0fed29972877ca5bd909469d03f26d3b8f837043d",
                             "3efee976d6565edd1492aa1047ffa10be6025de18206f6c68f91dd218801778f",

--- a/actions/linux-backdoor-kanada-team-short.json
+++ b/actions/linux-backdoor-kanada-team-short.json
@@ -20,7 +20,7 @@
                         "paths": [
                             "/bin/ls"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "adbee847c12c73605ff657e668c8096df138f824eb542027a10c0b5c07619c8d"
                         ]
                     },
@@ -29,7 +29,7 @@
                         "paths": [
                             "/bin/netstat"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "39823089fa324ceba00d5939d2e7b308fec28ee0f16c6caa4739a53ad6ecee64"
                         ]
                     },
@@ -38,7 +38,7 @@
                         "paths": [
                             "/bin/ps"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "72a44f3e7c4d9c9b72b1bda77d687346447d8e398983965b8e690eeeadebdc76"
                         ]
                     },
@@ -47,7 +47,7 @@
                         "paths": [
                             "/sbin/ifconfig"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "89a400077d74d1d76103180f41f40de6bcfffc89de461f497eef2ea763a68d73"
                         ]
                     },
@@ -56,7 +56,7 @@
                         "paths": [
                             "/usr/bin/dir"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "adbee847c12c73605ff657e668c8096df138f824eb542027a10c0b5c07619c8d"
                         ]
                     },
@@ -65,7 +65,7 @@
                         "paths": [
                             "/usr/bin/find"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "3efee976d6565edd1492aa1047ffa10be6025de18206f6c68f91dd218801778f"
                         ]
                     },
@@ -74,7 +74,7 @@
                         "paths": [
                             "/usr/bin/md5sum"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "89b68f8ea6a32d525fbf491878980180ffa395b042ea3104b11da229bade71db"
                         ]
                     },
@@ -83,7 +83,7 @@
                         "paths": [
                             "/usr/bin/ps"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "72a44f3e7c4d9c9b72b1bda77d687346447d8e398983965b8e690eeeadebdc76"
                         ]
                     },
@@ -92,7 +92,7 @@
                         "paths": [
                             "/usr/bin/pstree"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "dbe7fc18667cd75317d494ed3b32cfe3cd077c870d015dc18b406a4a39747f55"
                         ]
                     },
@@ -101,7 +101,7 @@
                         "paths": [
                             "/usr/bin/slocate"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "6114624bf5d7e29f738f939bcc2bc794de9bf377a571fe1e84ae9159794308cf"
                         ]
                     },
@@ -110,7 +110,7 @@
                         "paths": [
                             "/usr/bin/top"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "286c39ec3d8e4f15f353dca350ca7575e0269dba808206f3ce8d1a3ea142b353"
                         ]
                     },
@@ -119,7 +119,7 @@
                         "paths": [
                             "/usr/sbin/lsof"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "939cc74b5343bde1a17dfa270f8e6dc719a4bc6b3143f4581b401c81fd9a110d"
                         ]
                     },
@@ -128,7 +128,7 @@
                         "paths": [
                             "/usr/sbin/netstat"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "39823089fa324ceba00d5939d2e7b308fec28ee0f16c6caa4739a53ad6ecee64"
                         ]
                     }

--- a/actions/linux-backdoor.json
+++ b/actions/linux-backdoor.json
@@ -25,7 +25,7 @@
                             "/opt/*",
                             "/tmp/*"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "adbee847c12c73605ff657e668c8096df138f824eb542027a10c0b5c07619c8d",
                             "7c9816b5f1b840eb8c5ecfc0fed29972877ca5bd909469d03f26d3b8f837043d",
                             "3efee976d6565edd1492aa1047ffa10be6025de18206f6c68f91dd218801778f",

--- a/actions/shellshock_iocs.json
+++ b/actions/shellshock_iocs.json
@@ -19,7 +19,7 @@
               "/tmp",
               "/var/tmp"
             ],
-            "sha256": [
+            "sha2": [
               "73b0d95541c84965fa42c3e257bb349957b3be626dec9d55efcc6ebcba6fa489",
               "ae3b4f296957ee0a208003569647f04e585775be1f3992921af996b320cf520b",
               "2d3e0be24ef668b85ed48e81ebb50dce50612fb8dce96879f80306701bc41614",

--- a/actions/sshd_backdoor.json
+++ b/actions/sshd_backdoor.json
@@ -21,7 +21,7 @@
                         "paths": [
                             "/usr/sbin/"
                         ],
-                        "sha256": [
+                        "sha2": [
                             "ebfd9354ed83635ed38bd117b375903f9984a18780ef86dbf7a642fc6584271c"
                         ]
                     }

--- a/doc/module_file.html
+++ b/doc/module_file.html
@@ -258,7 +258,7 @@ label (key) and search parameters (value).</p><p>A search label is a string betw
                             <span class="name tag">"modes"</span><span class="punctuation">:</span> <span class="punctuation">[</span>
                                     <span class="literal string double">"^-r-xr-x--"</span>
                             <span class="punctuation">]</span>
-                            <span class="literal string double">"sha256"</span><span class="punctuation">:</span> <span class="punctuation">[</span>
+                            <span class="literal string double">"sha2"</span><span class="punctuation">:</span> <span class="punctuation">[</span>
                                     <span class="literal string double">"fff415292dc59cc99d43e70fd69347d09b9bd7a581f4d77b6ec0fa902ebaaec8"</span>
                             <span class="punctuation">],</span>
                             <span class="name tag">"options"</span><span class="punctuation">:</span> <span class="punctuation">{</span>
@@ -307,7 +307,8 @@ file. Inspection stops at the first occurence of the regular expression that
 matches on the file.
 If the regex is prefixed with "!", it will return files that do not have the
 content that matches the expression. ex: <cite>!^root:$6</cite> will return files that
-do not contain the string "root:$6".</p></li><li><p><strong>md5</strong>: a md5 checksum</p></li><li><p><strong>sha1</strong>: a sha1 checksum</p></li><li><p><strong>sha256</strong>: a sha256 checksum</p></li><li><p><strong>sha384</strong>: a sha384 checksum</p></li><li><p><strong>sha512</strong>: a sha512 checksum</p></li><li><p><strong>sha3_224</strong>: a sha3_224 checksum</p></li><li><p><strong>sha3_256</strong>: a sha3_256 checksum</p></li><li><p><strong>sha3_384</strong>: a sha3_384 checksum</p></li><li><p><strong>sha3_512</strong>: a sha3_512 checksum</p></li></ul></section><section id="search-options"><header><h3><a href="#id4">1.3   Search Options</a></h3></header><p>Several options can be applied to a search:</p><ul><li><p><strong>maxdepth</strong> controls the maximum number of directories that can be traversed
+do not contain the string "root:$6".</p></li><li><p><strong>md5</strong>: a md5 checksum</p></li><li><p><strong>sha1</strong>: a sha1 checksum</p></li><li><p><strong>sha2</strong>: a sha2 checksum (sha256/sha384/sha512 decided based on hash length)</p></li><li><p><strong>sha3</strong>: a sha3 checksum (sha3_224/sha3_256/sha3_384/sha3_512 decided based
+on hash length)</p></li></ul></section><section id="search-options"><header><h3><a href="#id4">1.3   Search Options</a></h3></header><p>Several options can be applied to a search:</p><ul><li><p><strong>maxdepth</strong> controls the maximum number of directories that can be traversed
 by a search. For example, is a search has path <cite>/home</cite>, and <cite>maxdepth</cite> is set
 to the value 3, the deepest directory that can be visited is
 <cite>/home/dir1/dir2/dir3</cite>.</p></li><li><p><strong>matchall</strong> indicates that within a given search, all search filters must
@@ -332,12 +333,15 @@ content. The <cite>macroal</cite> flag indicates that all lines of a file must m
 content regex. The <cite>mismatch</cite> flag inverses that logic, and thus if a least
 one line does not match the content regex, the file will be returned as a
 match.</p><p>The <cite>mismatch</cite> option can be applied to all check types: name, size, mode,
-mtime, content, md5, sha1, sha256, ... It can be specified multiple times:</p><p>example: <cite>-path /usr -name "^vim$" -content "linux-x86-64.so" -sha1 943633c85bb80d39532450decf1f723735313f1f -sha1 350ac204ac8084590b209c33f39f09986f0ba682 -mismatch=content -mismatch=sha1</cite></p></li><li><p><strong>matchlimit</strong> controls how many files can be returned by a single search.
+mtime, content, md5, sha1, sha2, ... It can be specified multiple times:</p><p>example: <cite>-path /usr -name "^vim$" -content "linux-x86-64.so" -sha1 943633c85bb80d39532450decf1f723735313f1f -sha1 350ac204ac8084590b209c33f39f09986f0ba682 -mismatch=content -mismatch=sha1</cite></p></li><li><p><strong>matchlimit</strong> controls how many files can be returned by a single search.
 This safeguard prevents a single run of the file module from crashing before
 of the amount of results it is returning. The default value is 1,000, which is
 already significant. If you plan on returning more than 1,000 results in a
 single file search, you should probably consider breaking it down into smaller
-searches, or running the search locally instead of through MIG.</p></li></ul></section></section><section id="search-algorithm"><header><h2><a href="#id5">2   Search algorithm</a></h2></header><p>FM traverse a directory tree starting from a root path and until no search are
+searches, or running the search locally instead of through MIG.</p></li><li><p><strong>returnsha256</strong> instructs the agent to return the SHA256 hash for any
+matched files. The client will display the hash with the file information
+in the result. As an example, this option can be used to do basic file
+integrity monitoring across actions.</p></li></ul></section></section><section id="search-algorithm"><header><h2><a href="#id5">2   Search algorithm</a></h2></header><p>FM traverse a directory tree starting from a root path and until no search are
 longer active. FM traverses a given path only once, regardless of the number of
 searches that are being performed. When FM enters a directory, it activates
 searches that apply to the directory, and deactivates the ones that don't.

--- a/mig-api/compliance.go
+++ b/mig-api/compliance.go
@@ -132,47 +132,17 @@ func commandsToComplianceItems(commands []mig.Command) (items []ComplianceItem, 
 							}
 							bitem.Check.Test.Value += fmt.Sprintf("sha1='%s'", v)
 						}
-						for _, v := range mf.Search.SHA256 {
+						for _, v := range mf.Search.SHA2 {
 							if len(bitem.Check.Test.Value) > 0 {
 								bitem.Check.Test.Value += " and "
 							}
-							bitem.Check.Test.Value += fmt.Sprintf("sha256='%s'", v)
+							bitem.Check.Test.Value += fmt.Sprintf("sha2='%s'", v)
 						}
-						for _, v := range mf.Search.SHA384 {
+						for _, v := range mf.Search.SHA3 {
 							if len(bitem.Check.Test.Value) > 0 {
 								bitem.Check.Test.Value += " and "
 							}
-							bitem.Check.Test.Value += fmt.Sprintf("sha384='%s'", v)
-						}
-						for _, v := range mf.Search.SHA512 {
-							if len(bitem.Check.Test.Value) > 0 {
-								bitem.Check.Test.Value += " and "
-							}
-							bitem.Check.Test.Value += fmt.Sprintf("sha512='%s'", v)
-						}
-						for _, v := range mf.Search.SHA3_224 {
-							if len(bitem.Check.Test.Value) > 0 {
-								bitem.Check.Test.Value += " and "
-							}
-							bitem.Check.Test.Value += fmt.Sprintf("sha3_224='%s'", v)
-						}
-						for _, v := range mf.Search.SHA3_256 {
-							if len(bitem.Check.Test.Value) > 0 {
-								bitem.Check.Test.Value += " and "
-							}
-							bitem.Check.Test.Value += fmt.Sprintf("sha3_256='%s'", v)
-						}
-						for _, v := range mf.Search.SHA3_384 {
-							if len(bitem.Check.Test.Value) > 0 {
-								bitem.Check.Test.Value += " and "
-							}
-							bitem.Check.Test.Value += fmt.Sprintf("sha3_384='%s'", v)
-						}
-						for _, v := range mf.Search.SHA3_512 {
-							if len(bitem.Check.Test.Value) > 0 {
-								bitem.Check.Test.Value += " and "
-							}
-							bitem.Check.Test.Value += fmt.Sprintf("sha3_512='%s'", v)
+							bitem.Check.Test.Value += fmt.Sprintf("sha3='%s'", v)
 						}
 						if mf.File == "" {
 							for i, p := range mf.Search.Paths {

--- a/modules/file/doc.rst
+++ b/modules/file/doc.rst
@@ -50,7 +50,7 @@ A search must have at least one search path.
 				"modes": [
 					"^-r-xr-x--"
 				]
-				"sha256": [
+				"sha2": [
 					"fff415292dc59cc99d43e70fd69347d09b9bd7a581f4d77b6ec0fa902ebaaec8"
 				],
 				"options": {
@@ -137,19 +137,10 @@ Content filters:
 
 * **sha1**: a sha1 checksum
 
-* **sha256**: a sha256 checksum
+* **sha2**: a sha2 checksum (sha256/sha384/sha512 decided based on hash length)
 
-* **sha384**: a sha384 checksum
-
-* **sha512**: a sha512 checksum
-
-* **sha3_224**: a sha3_224 checksum
-
-* **sha3_256**: a sha3_256 checksum
-
-* **sha3_384**: a sha3_384 checksum
-
-* **sha3_512**: a sha3_512 checksum
+* **sha3**: a sha3 checksum (sha3_224/sha3_256/sha3_384/sha3_512 decided based
+  on hash length)
 
 Search Options
 ~~~~~~~~~~~~~~
@@ -207,7 +198,7 @@ Several options can be applied to a search:
   match.
 
   The `mismatch` option can be applied to all check types: name, size, mode,
-  mtime, content, md5, sha1, sha256, ... It can be specified multiple times:
+  mtime, content, md5, sha1, sha2, ... It can be specified multiple times:
 
   example: `-path /usr -name "^vim$" -content "linux-x86-64\.so" -sha1 943633c85bb80d39532450decf1f723735313f1f -sha1 350ac204ac8084590b209c33f39f09986f0ba682 -mismatch=content -mismatch=sha1`
 

--- a/modules/file/file.go
+++ b/modules/file/file.go
@@ -79,13 +79,8 @@ type search struct {
 	Mtimes       []string `json:"mtimes,omitempty"`
 	MD5          []string `json:"md5,omitempty"`
 	SHA1         []string `json:"sha1,omitempty"`
-	SHA256       []string `json:"sha256,omitempty"`
-	SHA384       []string `json:"sha384,omitempty"`
-	SHA512       []string `json:"sha512,omitempty"`
-	SHA3_224     []string `json:"sha3_224,omitempty"`
-	SHA3_256     []string `json:"sha3_256,omitempty"`
-	SHA3_384     []string `json:"sha3_384,omitempty"`
-	SHA3_512     []string `json:"sha3_512,omitempty"`
+	SHA2         []string `json:"sha2,omitempty"`
+	SHA3         []string `json:"sha3,omitempty"`
 	Options      options  `json:"options,omitempty"`
 	checks       []check
 	checkmask    checkType
@@ -241,72 +236,38 @@ func (s *search) makeChecks() (err error) {
 		s.checks = append(s.checks, c)
 		s.checkmask |= c.code
 	}
-	for _, v := range s.SHA256 {
+	for _, v := range s.SHA2 {
 		var c check
-		c.code = checkSHA256
 		c.value = strings.ToUpper(v)
-		if s.hasMismatch("sha256") {
+		if s.hasMismatch("sha2") {
 			c.mismatch = true
+		}
+		switch len(v) {
+		case 64:
+			c.code = checkSHA256
+		case 96:
+			c.code = checkSHA384
+		case 128:
+			c.code = checkSHA512
 		}
 		s.checks = append(s.checks, c)
 		s.checkmask |= c.code
 	}
-	for _, v := range s.SHA384 {
+	for _, v := range s.SHA3 {
 		var c check
-		c.code = checkSHA384
 		c.value = strings.ToUpper(v)
-		if s.hasMismatch("sha384") {
+		if s.hasMismatch("sha3") {
 			c.mismatch = true
 		}
-		s.checks = append(s.checks, c)
-		s.checkmask |= c.code
-	}
-	for _, v := range s.SHA512 {
-		var c check
-		c.code = checkSHA512
-		c.value = strings.ToUpper(v)
-		if s.hasMismatch("sha512") {
-			c.mismatch = true
-		}
-		s.checks = append(s.checks, c)
-		s.checkmask |= c.code
-	}
-	for _, v := range s.SHA3_224 {
-		var c check
-		c.code = checkSHA3_224
-		c.value = strings.ToUpper(v)
-		if s.hasMismatch("sha3_224") {
-			c.mismatch = true
-		}
-		s.checks = append(s.checks, c)
-		s.checkmask |= c.code
-	}
-	for _, v := range s.SHA3_256 {
-		var c check
-		c.code = checkSHA3_256
-		c.value = strings.ToUpper(v)
-		if s.hasMismatch("sha3_256") {
-			c.mismatch = true
-		}
-		s.checks = append(s.checks, c)
-		s.checkmask |= c.code
-	}
-	for _, v := range s.SHA3_384 {
-		var c check
-		c.code = checkSHA3_384
-		c.value = strings.ToUpper(v)
-		if s.hasMismatch("sha3_384") {
-			c.mismatch = true
-		}
-		s.checks = append(s.checks, c)
-		s.checkmask |= c.code
-	}
-	for _, v := range s.SHA3_512 {
-		var c check
-		c.code = checkSHA3_512
-		c.value = strings.ToUpper(v)
-		if s.hasMismatch("sha3_512") {
-			c.mismatch = true
+		switch len(v) {
+		case 56:
+			c.code = checkSHA3_224
+		case 64:
+			c.code = checkSHA3_256
+		case 96:
+			c.code = checkSHA3_384
+		case 128:
+			c.code = checkSHA3_512
 		}
 		s.checks = append(s.checks, c)
 		s.checkmask |= c.code
@@ -512,51 +473,36 @@ func (r *run) ValidateParameters() (err error) {
 				return
 			}
 		}
-		for _, hash := range s.SHA256 {
+		for _, hash := range s.SHA2 {
 			debugprint("validating hash '%s'\n", hash)
-			err = validateHash(hash, checkSHA256)
+			switch len(hash) {
+			case 64:
+				err = validateHash(hash, checkSHA256)
+			case 96:
+				err = validateHash(hash, checkSHA384)
+			case 128:
+				err = validateHash(hash, checkSHA512)
+			default:
+				fmt.Printf("ERROR: Invalid hash length")
+			}
 			if err != nil {
 				return
 			}
 		}
-		for _, hash := range s.SHA384 {
+		for _, hash := range s.SHA3 {
 			debugprint("validating hash '%s'\n", hash)
-			err = validateHash(hash, checkSHA384)
-			if err != nil {
-				return
+			switch len(hash) {
+			case 56:
+				err = validateHash(hash, checkSHA3_224)
+			case 64:
+				err = validateHash(hash, checkSHA3_256)
+			case 96:
+				err = validateHash(hash, checkSHA3_384)
+			case 128:
+				err = validateHash(hash, checkSHA3_512)
+			default:
+				fmt.Printf("ERROR: Invalid hash length")
 			}
-		}
-		for _, hash := range s.SHA512 {
-			debugprint("validating hash '%s'\n", hash)
-			err = validateHash(hash, checkSHA512)
-			if err != nil {
-				return
-			}
-		}
-		for _, hash := range s.SHA3_224 {
-			debugprint("validating hash '%s'\n", hash)
-			err = validateHash(hash, checkSHA3_224)
-			if err != nil {
-				return
-			}
-		}
-		for _, hash := range s.SHA3_256 {
-			debugprint("validating hash '%s'\n", hash)
-			err = validateHash(hash, checkSHA3_256)
-			if err != nil {
-				return
-			}
-		}
-		for _, hash := range s.SHA3_384 {
-			debugprint("validating hash '%s'\n", hash)
-			err = validateHash(hash, checkSHA3_384)
-			if err != nil {
-				return
-			}
-		}
-		for _, hash := range s.SHA3_512 {
-			debugprint("validating hash '%s'\n", hash)
-			err = validateHash(hash, checkSHA3_512)
 			if err != nil {
 				return
 			}
@@ -665,7 +611,7 @@ func validateMismatch(filter string) error {
 	if len(filter) < 1 {
 		return fmt.Errorf("empty filters are not permitted")
 	}
-	filterregexp := `^(name|size|mode|mtime|content|md5|sha1|sha256|sha384|sha512|sha3_224|sha3_256|sha3_384|sha3_512)$`
+	filterregexp := `^(name|size|mode|mtime|content|md5|sha1|sha2|sha3)$`
 	re := regexp.MustCompile(filterregexp)
 	if !re.MatchString(filter) {
 		return fmt.Errorf("The syntax of filter '%s' is invalid. Must match regex %s", filter, filterregexp)
@@ -1665,19 +1611,14 @@ func (r *run) buildResults(t0 time.Time) (resStr string, err error) {
 				case checkSHA1:
 					mf.Search.SHA1 = append(mf.Search.SHA1, c.value)
 				case checkSHA256:
-					mf.Search.SHA256 = append(mf.Search.SHA256, c.value)
 				case checkSHA384:
-					mf.Search.SHA384 = append(mf.Search.SHA384, c.value)
 				case checkSHA512:
-					mf.Search.SHA512 = append(mf.Search.SHA512, c.value)
+					mf.Search.SHA2 = append(mf.Search.SHA2, c.value)
 				case checkSHA3_224:
-					mf.Search.SHA3_224 = append(mf.Search.SHA3_224, c.value)
 				case checkSHA3_256:
-					mf.Search.SHA3_256 = append(mf.Search.SHA3_256, c.value)
 				case checkSHA3_384:
-					mf.Search.SHA3_384 = append(mf.Search.SHA3_384, c.value)
 				case checkSHA3_512:
-					mf.Search.SHA3_512 = append(mf.Search.SHA3_512, c.value)
+					mf.Search.SHA3 = append(mf.Search.SHA2, c.value)
 				}
 				sr = append(sr, mf)
 			}
@@ -1777,26 +1718,11 @@ func (r *run) PrintResults(result modules.Result, foundOnly bool) (prints []stri
 			for _, v := range mf.Search.SHA1 {
 				out += fmt.Sprintf(" sha1='%s'", v)
 			}
-			for _, v := range mf.Search.SHA256 {
-				out += fmt.Sprintf(" sha256='%s'", v)
+			for _, v := range mf.Search.SHA2 {
+				out += fmt.Sprintf(" sha2='%s'", v)
 			}
-			for _, v := range mf.Search.SHA384 {
-				out += fmt.Sprintf(" sha384='%s'", v)
-			}
-			for _, v := range mf.Search.SHA512 {
-				out += fmt.Sprintf(" sha512='%s'", v)
-			}
-			for _, v := range mf.Search.SHA3_224 {
-				out += fmt.Sprintf(" sha3_224='%s'", v)
-			}
-			for _, v := range mf.Search.SHA3_256 {
-				out += fmt.Sprintf(" sha3_256='%s'", v)
-			}
-			for _, v := range mf.Search.SHA3_384 {
-				out += fmt.Sprintf(" sha3_384='%s'", v)
-			}
-			for _, v := range mf.Search.SHA3_512 {
-				out += fmt.Sprintf(" sha3_512='%s'", v)
+			for _, v := range mf.Search.SHA3 {
+				out += fmt.Sprintf(" sha3='%s'", v)
 			}
 			prints = append(prints, out)
 		}

--- a/modules/file/file_test.go
+++ b/modules/file/file_test.go
@@ -200,8 +200,7 @@ func TestMode(t *testing.T) {
 }
 
 func TestHashes(t *testing.T) {
-	for _, hashtype := range []string{`md5`, `sha1`, `sha256`, `sha384`, `sha512`,
-		`sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`} {
+	for _, hashtype := range []string{`md5`, `sha1`, `sha2`, `sha3`} {
 		for _, tp := range TESTDATA {
 			var (
 				r run
@@ -218,20 +217,10 @@ func TestHashes(t *testing.T) {
 				s.MD5 = append(s.MD5, tp.md5)
 			case `sha1`:
 				s.SHA1 = append(s.SHA1, tp.sha1)
-			case `sha256`:
-				s.SHA256 = append(s.SHA256, tp.sha256)
-			case `sha384`:
-				s.SHA384 = append(s.SHA384, tp.sha384)
-			case `sha512`:
-				s.SHA512 = append(s.SHA512, tp.sha512)
-			case `sha3_224`:
-				s.SHA3_224 = append(s.SHA3_224, tp.sha3_224)
-			case `sha3_256`:
-				s.SHA3_256 = append(s.SHA3_256, tp.sha3_256)
-			case `sha3_384`:
-				s.SHA3_384 = append(s.SHA3_384, tp.sha3_384)
-			case `sha3_512`:
-				s.SHA3_512 = append(s.SHA3_512, tp.sha3_512)
+			case `sha2`:
+				s.SHA2 = append(s.SHA2, tp.sha2)
+			case `sha3`:
+				s.SHA3 = append(s.SHA3, tp.sha3)
 			}
 			r.Parameters.Searches["s1"] = s
 			msg, err := modules.MakeMessage(modules.MsgClassParameters, r.Parameters)
@@ -266,13 +255,8 @@ func TestAllHashes(t *testing.T) {
 		s.Paths = append(s.Paths, basedir)
 		s.MD5 = append(s.MD5, tp.md5)
 		s.SHA1 = append(s.SHA1, tp.sha1)
-		s.SHA256 = append(s.SHA256, tp.sha256)
-		s.SHA384 = append(s.SHA384, tp.sha384)
-		s.SHA512 = append(s.SHA512, tp.sha512)
-		s.SHA3_224 = append(s.SHA3_224, tp.sha3_224)
-		s.SHA3_256 = append(s.SHA3_256, tp.sha3_256)
-		s.SHA3_384 = append(s.SHA3_384, tp.sha3_384)
-		s.SHA3_512 = append(s.SHA3_512, tp.sha3_512)
+		s.SHA2 = append(s.SHA2, tp.sha2)
+		s.SHA3 = append(s.SHA3, tp.sha3)
 		s.Options.MatchAll = true
 		r.Parameters.Searches["s1"] = s
 		msg, err := modules.MakeMessage(modules.MsgClassParameters, r.Parameters)
@@ -403,7 +387,7 @@ type mismatchtest struct {
 func TestMismatch(t *testing.T) {
 	var MismatchTestCases = []mismatchtest{
 		mismatchtest{
-			desc: "want files that don't match name '^testfile0' with maxdept=1, should find testfile1 and testfile2",
+			desc: "want files that don't match name '^testfile0' with maxdepth=1, should find testfile1, 2, 3, 4 & 5",
 			search: search{
 				Paths: []string{basedir},
 				Names: []string{"^" + TESTDATA[0].name + "$"},
@@ -414,10 +398,13 @@ func TestMismatch(t *testing.T) {
 			},
 			expectedfiles: []string{
 				basedir + "/" + TESTDATA[1].name,
-				basedir + "/" + TESTDATA[2].name},
+				basedir + "/" + TESTDATA[2].name,
+				basedir + "/" + TESTDATA[3].name,
+				basedir + "/" + TESTDATA[4].name,
+				basedir + "/" + TESTDATA[5].name},
 		},
 		mismatchtest{
-			desc: "want files that don't have a size of 190 bytes or larger than 10{k,m,g,t} or smaller than 10 bytes, should find testfile1 and testfile2",
+			desc: "want files that don't have a size of 190 bytes or larger than 10{k,m,g,t} or smaller than 10 bytes, should find testfile1, 2 & 3",
 			search: search{
 				Paths: []string{basedir},
 				Sizes: []string{"190", ">10k", ">10m", ">10g", ">10t", "<10"},
@@ -429,7 +416,10 @@ func TestMismatch(t *testing.T) {
 			},
 			expectedfiles: []string{
 				basedir + "/" + TESTDATA[1].name,
-				basedir + "/" + TESTDATA[2].name},
+				basedir + "/" + TESTDATA[2].name,
+				basedir + "/" + TESTDATA[3].name,
+				basedir + "/" + TESTDATA[4].name,
+				basedir + "/" + TESTDATA[5].name},
 		},
 		mismatchtest{
 			desc: "want files that have not been modified in the last hour ago, should find nothing",
@@ -454,7 +444,7 @@ func TestMismatch(t *testing.T) {
 			expectedfiles: []string{""},
 		},
 		mismatchtest{
-			desc: "want files that don't a name different than testfile0, should find testfile0",
+			desc: "want files that don't have a name different than testfile0, should find testfile0",
 			search: search{
 				Paths: []string{basedir},
 				Names: []string{"!^testfile0$"},
@@ -483,28 +473,25 @@ func TestMismatch(t *testing.T) {
 				basedir + subdirs + TESTDATA[1].name},
 		},
 		mismatchtest{
-			desc: "want files that don't match the hashes of testfile2, should find testfile0 & 1",
+			desc: "want files that don't match the hashes of testfile2, should find testfile0, 1, 3, 4, & 5",
 			search: search{
-				Paths:    []string{basedir},
-				MD5:      []string{TESTDATA[2].md5},
-				SHA1:     []string{TESTDATA[2].sha1},
-				SHA256:   []string{TESTDATA[2].sha256},
-				SHA384:   []string{TESTDATA[2].sha384},
-				SHA512:   []string{TESTDATA[2].sha512},
-				SHA3_224: []string{TESTDATA[2].sha3_224},
-				SHA3_256: []string{TESTDATA[2].sha3_256},
-				SHA3_384: []string{TESTDATA[2].sha3_384},
-				SHA3_512: []string{TESTDATA[2].sha3_512},
+				Paths: []string{basedir},
+				MD5:   []string{TESTDATA[2].md5},
+				SHA1:  []string{TESTDATA[2].sha1},
+				SHA2:  []string{TESTDATA[2].sha2},
+				SHA3:  []string{TESTDATA[2].sha3},
 				Options: options{
 					MaxDepth: 1,
 					MatchAll: true,
-					Mismatch: []string{`md5`, `sha1`, `sha256`, `sha384`, `sha512`,
-						`sha3_224`, `sha3_256`, `sha3_384`, `sha3_512`},
+					Mismatch: []string{`md5`, `sha1`, `sha2`, `sha3`},
 				},
 			},
 			expectedfiles: []string{
 				basedir + "/" + TESTDATA[0].name,
-				basedir + "/" + TESTDATA[1].name},
+				basedir + "/" + TESTDATA[1].name,
+				basedir + "/" + TESTDATA[3].name,
+				basedir + "/" + TESTDATA[4].name,
+				basedir + "/" + TESTDATA[5].name},
 		},
 	}
 
@@ -547,13 +534,8 @@ func TestParamsParser(t *testing.T) {
 	args = append(args, "-mtime", TESTDATA[0].mtime)
 	args = append(args, "-md5", TESTDATA[0].md5)
 	args = append(args, "-sha1", TESTDATA[0].sha1)
-	args = append(args, "-sha256", TESTDATA[0].sha256)
-	args = append(args, "-sha384", TESTDATA[0].sha384)
-	args = append(args, "-sha512", TESTDATA[0].sha512)
-	args = append(args, "-sha3_224", TESTDATA[0].sha3_224)
-	args = append(args, "-sha3_256", TESTDATA[0].sha3_256)
-	args = append(args, "-sha3_384", TESTDATA[0].sha3_384)
-	args = append(args, "-sha3_512", TESTDATA[0].sha3_512)
+	args = append(args, "-sha2", TESTDATA[0].sha2)
+	args = append(args, "-sha3", TESTDATA[0].sha3)
 	args = append(args, "-matchany")
 	args = append(args, "-matchall")
 	args = append(args, "-macroal")
@@ -651,8 +633,7 @@ const subdirs string = `/a/b/c/d/e/f/g/h/i/j/k/l/m/n/`
 type testParams struct {
 	data []byte
 	name, size, mode, mtime, content,
-	md5, sha1, sha256, sha384, sha512,
-	sha3_224, sha3_256, sha3_384, sha3_512 string
+	md5, sha1, sha2, sha3 string
 }
 
 var TESTDATA = []testParams{
@@ -665,44 +646,33 @@ var TESTDATA = []testParams{
 # above is an empty line, no spaces
 some text
 some other text`),
-		name:     `testfile0`,
-		size:     `190`,
-		mode:     `-rw-r--r--`,
-		mtime:    `<1m`,
-		content:  `^--- header for first file ---$`,
-		md5:      `e499c1912bd9af4f7e8ccaf27f7b04d2`,
-		sha1:     `d7bbc3dd7adf6e347c93a4c8b9bfb8ef4748c0fb`,
-		sha256:   `4d8ef27c4415d71cbbfad1eaa97d6f2a3ddacc9708b66efbb726133b9fd3d79a`,
-		sha384:   `8bf7ca66a8cd73b252e1431e350ef415034b211ea4d7711189b0b3f664c6fd372ed4a8f454ffc7e577a828a97a30074b`,
-		sha512:   `bd6e6a312a5fe4998df5d6ace15837355e1465ed3d32188ec56551279f70b51cf168e5c83d1f60bf66c15b70c0b2e51b4a728f3a0046d46db9a9e566c2db3daf`,
-		sha3_224: `a7ba1e66174848ecea143b612f22168b006979e3827e09f0ae6395e8`,
-		sha3_256: `091dbb7c04406fb5d95dc1c3c1fbc0378a63f19472f42fdd133b826a2a5ea3a7`,
-		sha3_384: `5b33c1fff06dff46b62b89922dfbab786a7763601028a741b7d7f1c75b584ae88acaf07f672bd4902929e7168fd9de28`,
-		sha3_512: `c9cf248748858b3b1ea752f9c778889a9cf0abc23529da20147b9ffbd7254a82d949c85a399730b40b3603bb2bc41b9585de147d2cd7080938388615501c4a5e`,
+		name:    `testfile0`,
+		size:    `190`,
+		mode:    `-rw-r--r--`,
+		mtime:   `<1m`,
+		content: `^--- header for first file ---$`,
+		md5:     `e499c1912bd9af4f7e8ccaf27f7b04d2`,
+		sha1:    `d7bbc3dd7adf6e347c93a4c8b9bfb8ef4748c0fb`,
+		sha2:    `4d8ef27c4415d71cbbfad1eaa97d6f2a3ddacc9708b66efbb726133b9fd3d79a`,
+		sha3:    `a7ba1e66174848ecea143b612f22168b006979e3827e09f0ae6395e8`,
 	},
 	testParams{
 		data: []byte(`--- header for second file ---
 # this is a comment
                                        
 # above is an line filled with spaces
-
 # above is an empty line, no spaces
 some text
 some other other text`),
-		name:     `testfile1`,
-		size:     `197`,
-		mode:     `-rw-r--r--`,
-		mtime:    `<1m`,
-		content:  `^--- header for second file ---$`,
-		md5:      `63c7fa8ec03e72343d434835ff95c8a7`,
-		sha1:     `14dcc657c3362bc9adb12ff8c23e14940df42b6f`,
-		sha256:   `b665fabb0c6c5cd9fabfd3fdd222aa4cd56dceda82485acc263546d30a825634`,
-		sha384:   `fdd9460795c000f9143e5bdd8d7ffb153f7541c154682179a131f557fa0a878db51f0046672e486a9bdcb64cdaf76ca1`,
-		sha512:   `e40b2f00f2a4097b3f53bc33c60cd04750ce87016ec3c6ef05bea05f0c5f49c56f7d634448012b2bbb879c2ede43d5bd3bc0ce20873129c2caad9cb4d8bbe6da`,
-		sha3_224: `bae8d23a49eb7ac8c5c8589e6d089d4b127478132711d164d92ad244`,
-		sha3_256: `92d0f8878baff9ff926bb752de4e830d60ef05146be90e0b857a58402940f839`,
-		sha3_384: `f8b736cdc7e14afb264bafb287805a2d05397142cabe3a8d1b17c13f6b5bf62006b413814fdb7d04cd63ebe7a8c59542`,
-		sha3_512: `c501a1809064bf480b6260c0af7430e81547a854a41ce900707134210123db4ddfefd58f73a41b3072cef0a034b39d8d4ce01265d3ce30d0bf11e0ea26ec2dbd`,
+		name:    `testfile1`,
+		size:    `196`,
+		mode:    `-rw-r--r--`,
+		mtime:   `<1m`,
+		content: `^--- header for second file ---$`,
+		md5:     `072841679be61acd27de062da1ad6fdf`,
+		sha1:    `21f4a0f1d86915f9fa676b96a823c4c3142eb22b`,
+		sha2:    `72573e5f095cb29afa2486b519928ed153558a8c036f15a9d1f790c8989e96c3`,
+		sha3:    `7ec2e3b36e220b3c5ea9ad0129a1cdcd6dd7f545c92a90f8419ea05d408ca9d5ec999452fd804df7ede9ca0f0647195ae03eba1be7fae0c2217a8f24eaf7cce0`,
 	},
 	testParams{
 		data: []byte("\x35\xF3\x40\xD8\xE9\xCE\x96\x38\xBD\x02\x80\xE4\xED\xA8\xCE\x5F\x5D\xEB\xDB\x92" +
@@ -757,19 +727,64 @@ some other other text`),
 			"\x00\xF3\x39\x34\x84\x6D\x76\x69\xF0\x7D\x90\x39\x16\x84\x37\x52\xA5\x79\xCF\x20" +
 			"\x18\xC2\x00\x31\xCD\x6C\x38\x25\x5D\x47\xB6\x2B\x3F\xA0\x7D\xB3\x69\x85\xBF\xF8" +
 			"\x25\x38\x32\x35"),
-		name:     `testfile2`,
-		size:     `1024`,
-		mode:     `-rw-r--r--`,
-		mtime:    `<1m`,
-		content:  `skZ0`,
-		md5:      `8d3a7afb7e59693b383d52396243a5b8`,
-		sha1:     `d82bc1145d471714b056940b268032f9ab0df2ae`,
-		sha256:   `3b495fae5bae9751ea4706c29e992002ba277bce30bd83a827b01ba977eabc2f`,
-		sha384:   `e778dda037764db51a4aaaf1511f8415aa9e6b5f9e012d1fef4cfe5492bf11410cb37a5db2acf3580460a265bd0ace2e`,
-		sha512:   `36d988e223f086c95d45c804f3d4b0ab95e74b69c36d5bc8801dcd9d71c0e252e4987d8e2bcab348811e559c454bd9e18527fd66c3b0be1d53463c5d7a80e9f2`,
-		sha3_224: `fdb23afa808c265284c3199013e4ded9704eebf54ffdc1f016dacc12`,
-		sha3_256: `bb84ecae0ebff542bef1478e4f19523c910905a88669abb38fe86f8b1b1cc7a8`,
-		sha3_384: `5053ccfd9cc72aead52742ea89ef4ab87c7e8fac92d09983d6ea0b43d8f1e247338c6460a66a7e5f53293888b82e2720`,
-		sha3_512: `674b6d6b4868e7bf848c4ce9be4fa964e3907a78c82152dd7f009778015043810e0e6fd75f58fb4a706893f22f70cabab449ebde37b88cb645675c3df16ea347`,
+		name:    `testfile2`,
+		size:    `1024`,
+		mode:    `-rw-r--r--`,
+		mtime:   `<1m`,
+		content: `skZ0`,
+		md5:     `8d3a7afb7e59693b383d52396243a5b8`,
+		sha1:    `d82bc1145d471714b056940b268032f9ab0df2ae`,
+		sha2:    `3b495fae5bae9751ea4706c29e992002ba277bce30bd83a827b01ba977eabc2f`,
+		sha3:    `fdb23afa808c265284c3199013e4ded9704eebf54ffdc1f016dacc12`,
+	},
+	testParams{
+		data: []byte(`--- header for fourth file ---
+# above is an line filled with spaces
+
+# above is an empty line, no spaces
+some text
+some other text`),
+		name:    `testfile3`,
+		size:    `131`,
+		mode:    `-rw-r--r--`,
+		mtime:   `<1m`,
+		content: `^--- header for fourth file ---$`,
+		md5:     `d6b008f34e7cf207cb9bc74a2153fffd`,
+		sha1:    `9ee0213f3227fe4f3658af0c3de315669b36ccf9`,
+		sha2:    `fb9758f30549a282d41a4eb125790704c17309e55443dbb54895379b8e33438f2825b78b938aa3735f99f3305d3b98e8`,
+		sha3:    `fe66d22caa59899c386e0a041f641d1c8130ded8f7365330957cbf69`,
+	},
+	testParams{
+		data: []byte(`--- header for fifth file ---
+# this is a comment
+                                       
+# above is an empty line, no spaces
+some text
+some other text`),
+		name:    `testfile4`,
+		size:    `151`,
+		mode:    `-rw-r--r--`,
+		mtime:   `<1m`,
+		content: `^--- header for fifth file ---$`,
+		md5:     `5d5a4fdeafc1677dca8255ef9624d522`,
+		sha1:    `caf4ce81c990785e5041bfc410526f471ea1ba6f`,
+		sha2:    `a4001843158a7a374e5ddcc22644c0e37738bc64ffd50179fc18fb443e0a62393b43384d9ac734e7a64c204e862ae3424094381afb33dfc639c52517afad1f32`,
+		sha3:    `2028feaccf974066aa7c47070f24c72d349ed6a6575cb801cc606c4a2b59020af4339b60dbedd0049a7341edde14133ee6f8b199f1a7c6ef36493fd217501607`,
+	},
+	testParams{
+		data: []byte(`--- header for sixth file ---
+# this is a comment
+                                       
+some text
+some other text`),
+		name:    `testfile5`,
+		size:    `115`,
+		mode:    `-rw-r--r--`,
+		mtime:   `<1m`,
+		content: `^--- header for sixth file ---$`,
+		md5:     `f9132062fccc09cba5f93474724a57e3`,
+		sha1:    `fb03d2d4ac2a82090bc29934f75c1d6914bacc91`,
+		sha2:    `8871b2ff047be05571549398e54c1f36163ae171e05a89900468688ea3bac4f9f3d7c922f0bebc24fdac28d0b2d38fb2718209fb5976c9245e7c837170b79819`,
+		sha3:    `cb086f02b728d57e299651f89e1fb0f89c659db50c7c780ec2689a8143e55c8e5e63ab47fe20897be7155e409151c190`,
 	},
 }

--- a/modules/file/paramscreator.go
+++ b/modules/file/paramscreator.go
@@ -50,13 +50,9 @@ func printHelp(isCmd bool) {
 
 %smd5 <hash>      .
 %ssha1 <hash>     .
-%ssha256 <hash>   .
-%ssha384 <hash>   .
-%ssha512 <hash>   .
-%ssha3_224 <hash> .
-%ssha3_256 <hash> .
-%ssha3_384 <hash> .
-%ssha3_512 <hash> - compare file against given hash
+%ssha2 <hash>     .
+%ssha3 <hash>     - compare file against given hash
+ 
 
 
 Options
@@ -251,83 +247,54 @@ func (r *run) ParamsCreator() (interface{}, error) {
 					continue
 				}
 				search.SHA1 = append(search.SHA1, checkValue)
-			case "sha256":
+			case "sha2":
 				if checkValue == "" {
 					fmt.Println("Missing parameter, try again")
 					continue
 				}
-				err = validateHash(checkValue, checkSHA256)
+				var hashSize = len(checkValue)
+				hashType := checkContent
+				switch hashSize {
+				case 64:
+					hashType = checkSHA256
+				case 96:
+					hashType = checkSHA384
+				case 128:
+					hashType = checkSHA512
+				default:
+					fmt.Printf("ERROR: Invalid hash length")
+				}
+				err = validateHash(checkValue, hashType)
 				if err != nil {
 					fmt.Printf("ERROR: %v\nTry again.\n", err)
 					continue
 				}
-				search.SHA256 = append(search.SHA256, checkValue)
-			case "sha384":
+				search.SHA2 = append(search.SHA2, checkValue)
+			case "sha3":
 				if checkValue == "" {
 					fmt.Println("Missing parameter, try again")
 					continue
 				}
-				err = validateHash(checkValue, checkSHA384)
+				var hashSize = len(checkValue)
+				hashType := checkContent
+				switch hashSize {
+				case 56:
+					hashType = checkSHA3_224
+				case 64:
+					hashType = checkSHA3_256
+				case 96:
+					hashType = checkSHA3_384
+				case 128:
+					hashType = checkSHA3_512
+				default:
+					fmt.Printf("ERROR: Invalid hash length")
+				}
+				err = validateHash(checkValue, hashType)
 				if err != nil {
 					fmt.Printf("ERROR: %v\nTry again.\n", err)
 					continue
 				}
-				search.SHA384 = append(search.SHA384, checkValue)
-			case "sha512":
-				if checkValue == "" {
-					fmt.Println("Missing parameter, try again")
-					continue
-				}
-				err = validateHash(checkValue, checkSHA512)
-				if err != nil {
-					fmt.Printf("ERROR: %v\nTry again.\n", err)
-					continue
-				}
-				search.SHA512 = append(search.SHA512, checkValue)
-			case "sha3_224":
-				if checkValue == "" {
-					fmt.Println("Missing parameter, try again")
-					continue
-				}
-				err = validateHash(checkValue, checkSHA3_224)
-				if err != nil {
-					fmt.Printf("ERROR: %v\nTry again.\n", err)
-					continue
-				}
-				search.SHA3_224 = append(search.SHA3_224, checkValue)
-			case "sha3_256":
-				if checkValue == "" {
-					fmt.Println("Missing parameter, try again")
-					continue
-				}
-				err = validateHash(checkValue, checkSHA3_256)
-				if err != nil {
-					fmt.Printf("ERROR: %v\nTry again.\n", err)
-					continue
-				}
-				search.SHA3_256 = append(search.SHA3_256, checkValue)
-			case "sha3_384":
-				if checkValue == "" {
-					fmt.Println("Missing parameter, try again")
-					continue
-				}
-				err = validateHash(checkValue, checkSHA3_384)
-				if err != nil {
-					fmt.Printf("ERROR: %v\nTry again.\n", err)
-					continue
-				}
-				search.SHA3_384 = append(search.SHA3_384, checkValue)
-			case "sha3_512":
-				if checkValue == "" {
-					fmt.Println("Missing parameter, try again")
-					continue
-				}
-				err = validateHash(checkValue, checkSHA3_512)
-				if err != nil {
-					fmt.Printf("ERROR: %v\nTry again.\n", err)
-					continue
-				}
-				search.SHA3_512 = append(search.SHA3_512, checkValue)
+				search.SHA3 = append(search.SHA3, checkValue)
 			case "maxdepth":
 				if checkValue == "" {
 					fmt.Println("Missing parameter, try again")
@@ -400,8 +367,8 @@ exit:
 func (r *run) ParamsParser(args []string) (interface{}, error) {
 	var (
 		err error
-		paths, names, sizes, modes, mtimes, contents, md5s, sha1s, sha256s,
-		sha384s, sha512s, sha3_224s, sha3_256s, sha3_384s, sha3_512s, mismatch flagParam
+		paths, names, sizes, modes, mtimes, contents, md5s, sha1s, sha2s,
+		sha3s, mismatch flagParam
 		maxdepth, matchlimit                               float64
 		returnsha256, matchall, matchany, macroal, verbose bool
 		fs                                                 flag.FlagSet
@@ -419,13 +386,8 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	fs.Var(&contents, "content", "see help")
 	fs.Var(&md5s, "md5", "see help")
 	fs.Var(&sha1s, "sha1", "see help")
-	fs.Var(&sha256s, "sha256", "see help")
-	fs.Var(&sha384s, "sha384", "see help")
-	fs.Var(&sha512s, "sha512", "see help")
-	fs.Var(&sha3_224s, "sha3_224", "see help")
-	fs.Var(&sha3_256s, "sha3_256", "see help")
-	fs.Var(&sha3_384s, "sha3_384", "see help")
-	fs.Var(&sha3_512s, "sha3_512", "see help")
+	fs.Var(&sha2s, "sha2", "see help")
+	fs.Var(&sha3s, "sha3", "see help")
 	fs.Var(&mismatch, "mismatch", "see help")
 	fs.Float64Var(&maxdepth, "maxdepth", 1000, "see help")
 	fs.Float64Var(&matchlimit, "matchlimit", 1000, "see help")
@@ -447,13 +409,8 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	s.Contents = contents
 	s.MD5 = md5s
 	s.SHA1 = sha1s
-	s.SHA256 = sha256s
-	s.SHA384 = sha384s
-	s.SHA512 = sha512s
-	s.SHA3_224 = sha3_224s
-	s.SHA3_256 = sha3_256s
-	s.SHA3_384 = sha3_384s
-	s.SHA3_512 = sha3_512s
+	s.SHA2 = sha2s
+	s.SHA3 = sha3s
 	s.Options.MaxDepth = maxdepth
 	s.Options.MatchLimit = matchlimit
 	s.Options.Macroal = macroal

--- a/runner-plugins/runner-compliance/main.go
+++ b/runner-plugins/runner-compliance/main.go
@@ -206,47 +206,17 @@ func makeComplianceItem(cmd mig.Command) (items []gozdef.ComplianceItem, err err
 						}
 						ci.Check.Test.Value += fmt.Sprintf("sha1='%s'", v)
 					}
-					for _, v := range mf.Search.SHA256 {
+					for _, v := range mf.Search.SHA2 {
 						if len(ci.Check.Test.Value) > 0 {
 							ci.Check.Test.Value += " and "
 						}
-						ci.Check.Test.Value += fmt.Sprintf("sha256='%s'", v)
+						ci.Check.Test.Value += fmt.Sprintf("sha2='%s'", v)
 					}
-					for _, v := range mf.Search.SHA384 {
+					for _, v := range mf.Search.SHA3 {
 						if len(ci.Check.Test.Value) > 0 {
 							ci.Check.Test.Value += " and "
 						}
-						ci.Check.Test.Value += fmt.Sprintf("sha384='%s'", v)
-					}
-					for _, v := range mf.Search.SHA512 {
-						if len(ci.Check.Test.Value) > 0 {
-							ci.Check.Test.Value += " and "
-						}
-						ci.Check.Test.Value += fmt.Sprintf("sha512='%s'", v)
-					}
-					for _, v := range mf.Search.SHA3_224 {
-						if len(ci.Check.Test.Value) > 0 {
-							ci.Check.Test.Value += " and "
-						}
-						ci.Check.Test.Value += fmt.Sprintf("sha3_224='%s'", v)
-					}
-					for _, v := range mf.Search.SHA3_256 {
-						if len(ci.Check.Test.Value) > 0 {
-							ci.Check.Test.Value += " and "
-						}
-						ci.Check.Test.Value += fmt.Sprintf("sha3_256='%s'", v)
-					}
-					for _, v := range mf.Search.SHA3_384 {
-						if len(ci.Check.Test.Value) > 0 {
-							ci.Check.Test.Value += " and "
-						}
-						ci.Check.Test.Value += fmt.Sprintf("sha3_384='%s'", v)
-					}
-					for _, v := range mf.Search.SHA3_512 {
-						if len(ci.Check.Test.Value) > 0 {
-							ci.Check.Test.Value += " and "
-						}
-						ci.Check.Test.Value += fmt.Sprintf("sha3_512='%s'", v)
+						ci.Check.Test.Value += fmt.Sprintf("sha3='%s'", v)
 					}
 					if mf.File == "" {
 						for i, p := range mf.Search.Paths {


### PR DESCRIPTION
I tried fusing the hashes under sha2/sha3 as we discussed on IRC, but the tests aren't passing.

[Here](https://gist.github.com/therealkbhat/b2ffffa2e2ef7e22c9f3) is the error log.

So, this is a WIP, with the following points to be addressed:
* I need a bit of help on figuring out what's wrong with my code.
* I need to add more test cases to ensure that every way the "-sha2" and "-sha3" flags (with hashes of varying length) can be used are indeed tested.

Thanks in advance for your feedback!