### PR TITLE
[medium] Decompress files before content inspect, resolves #108

### DIFF
--- a/doc/module_file.html
+++ b/doc/module_file.html
@@ -263,7 +263,8 @@ label (key) and search parameters (value).</p><p>A search label is a string betw
                             <span class="punctuation">],</span>
                             <span class="name tag">"options"</span><span class="punctuation">:</span> <span class="punctuation">{</span>
                                     <span class="name tag">"matchall"</span><span class="punctuation">:</span> <span class="keyword constant">true</span><span class="punctuation">,</span>
-                                    <span class="name tag">"maxdepth"</span><span class="punctuation">:</span> <span class="literal number integer">3</span>
+                                    <span class="name tag">"maxdepth"</span><span class="punctuation">:</span> <span class="literal number integer">3</span><span class="punctuation">,</span>
+                                    <span class="name tag">"decompress"</span><span class="punctuation">:</span> <span class="keyword constant">true</span>
                             <span class="punctuation">}</span>
                     <span class="punctuation">}</span>
     <span class="punctuation">}</span>
@@ -341,7 +342,10 @@ single file search, you should probably consider breaking it down into smaller
 searches, or running the search locally instead of through MIG.</p></li><li><p><strong>returnsha256</strong> instructs the agent to return the SHA256 hash for any
 matched files. The client will display the hash with the file information
 in the result. As an example, this option can be used to do basic file
-integrity monitoring across actions.</p></li></ul></section></section><section id="search-algorithm"><header><h2><a href="#id5">2   Search algorithm</a></h2></header><p>FM traverse a directory tree starting from a root path and until no search are
+integrity monitoring across actions.</p></li><li><p><strong>decompress</strong> tells the agent to decompress gzipped files prior to
+inspecting content or calculating hashes. Note that if the decompress flag
+is set for one search, all searches will involve a test for file
+decompression.</p></li></ul></section></section><section id="search-algorithm"><header><h2><a href="#id5">2   Search algorithm</a></h2></header><p>FM traverse a directory tree starting from a root path and until no search are
 longer active. FM traverses a given path only once, regardless of the number of
 searches that are being performed. When FM enters a directory, it activates
 searches that apply to the directory, and deactivates the ones that don't.

--- a/modules/file/doc.rst
+++ b/modules/file/doc.rst
@@ -55,7 +55,8 @@ A search must have at least one search path.
 				],
 				"options": {
 					"matchall": true,
-					"maxdepth": 3
+					"maxdepth": 3,
+					"decompress": true
 				}
 			}
         }
@@ -213,6 +214,11 @@ Several options can be applied to a search:
   matched files. The client will display the hash with the file information
   in the result. As an example, this option can be used to do basic file
   integrity monitoring across actions.
+
+* **decompress** tells the agent to decompress gzipped files prior to
+  inspecting content or calculating hashes. Note that if the decompress flag
+  is set for one search, all searches will involve a test for file
+  decompression.
 
 Search algorithm
 ----------------

--- a/modules/file/paramscreator.go
+++ b/modules/file/paramscreator.go
@@ -76,6 +76,8 @@ Options
 			  is reached.
 %sreturnsha256		- include sha256 hash for matched files.
 			  ex: %sreturnsha256
+%sdecompress		- decompress file before inspection
+			  ex: %sdecompress
 
 Module documentation is at http://mig.mozilla.org/doc/module_file.html
 Cheatsheet and examples are at http://mig.mozilla.org/doc/cheatsheet.rst.html
@@ -100,6 +102,7 @@ func (r *run) ParamsCreator() (interface{}, error) {
 		search.Options.MatchAll = true
 		search.Options.MaxDepth = 1000
 		search.Options.MatchLimit = 1000
+		search.Options.Decompress = false
 		for {
 			fmt.Println("Give a name to this search, or 'done' to exit")
 			fmt.Printf("label> ")
@@ -347,6 +350,12 @@ func (r *run) ParamsCreator() (interface{}, error) {
 					continue
 				}
 				search.Options.MatchLimit = v
+			case "decompress":
+				if checkValue != "" {
+					fmt.Println("This option doesn't take arguments, try again")
+					continue
+				}
+				search.Options.Decompress = true
 			default:
 				fmt.Printf("Invalid method!\n")
 				continue
@@ -369,9 +378,9 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 		err error
 		paths, names, sizes, modes, mtimes, contents, md5s, sha1s, sha2s,
 		sha3s, mismatch flagParam
-		maxdepth, matchlimit                               float64
-		returnsha256, matchall, matchany, macroal, verbose bool
-		fs                                                 flag.FlagSet
+		maxdepth, matchlimit                                           float64
+		returnsha256, matchall, matchany, macroal, verbose, decompress bool
+		fs                                                             flag.FlagSet
 	)
 	if len(args) < 1 || args[0] == "" || args[0] == "help" {
 		printHelp(true)
@@ -396,6 +405,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	fs.BoolVar(&macroal, "macroal", false, "see help")
 	fs.BoolVar(&debug, "verbose", false, "see help")
 	fs.BoolVar(&returnsha256, "returnsha256", false, "see help")
+	fs.BoolVar(&decompress, "decompress", false, "see help")
 	err = fs.Parse(args)
 	if err != nil {
 		return nil, err
@@ -417,6 +427,7 @@ func (r *run) ParamsParser(args []string) (interface{}, error) {
 	s.Options.Mismatch = mismatch
 	s.Options.MatchAll = matchall
 	s.Options.ReturnSHA256 = returnsha256
+	s.Options.Decompress = decompress
 	if matchany {
 		s.Options.MatchAll = false
 	}


### PR DESCRIPTION
Work in progress.

`decompressFile` returns a file descriptor which gets passed to `checkContent` and `checkHash` from `evaluateFile`. Note that I haven't removed `file string` from those calls; it seemed less invasive to pass both the string as well as the file descriptor, especially since the string is used extensively in calls to `debugprint` and `storematch`.

Does leaving the fd open across multiple function calls (`checkContent`, all the `checkHash`s) lead to any problems?

I haven't gotten to tests or doc changes yet; thought I'd get feedback on this approach first. I also still need to look at dealing with multiple files in a single zip.