### PR TITLE
[medium] command compression between scheduler and agents

### DIFF
--- a/command.go
+++ b/command.go
@@ -7,6 +7,8 @@
 package mig /* import "mig.ninja/mig" */
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,9 +18,16 @@ import (
 )
 
 type Command struct {
-	ID     float64 `json:"id"`
-	Action Action  `json:"action"`
-	Agent  Agent   `json:"agent"`
+	ID    float64 `json:"id"`
+	Agent Agent   `json:"agent"`
+
+	// The command action. If CompressedAction is non-zero, this represents
+	// a GZIP compressed version of the marshaled action information, and is
+	// used when sending actions between the scheduler and agents. Compressed
+	// elements within the command should be manipulated using the
+	// command.Compress() and command.Decompress() functions.
+	Action           Action `json:"action"`
+	CompressedAction []byte `json:"compressed_action,omitempty"`
 
 	// Status can be one of:
 	// sent: the command has been sent by the scheduler to the agent
@@ -29,9 +38,125 @@ type Command struct {
 	// timeout: module execution has timed out, and the agent returned the command to the scheduler
 	Status string `json:"status"`
 
-	Results    []modules.Result `json:"results"`
-	StartTime  time.Time        `json:"starttime"`
-	FinishTime time.Time        `json:"finishtime"`
+	// Command results, which operate in a similar manner as described above for
+	// the command action.
+	Results           []modules.Result `json:"results"`
+	CompressedResults [][]byte         `json:"compressed_results,omitempty"`
+
+	StartTime  time.Time `json:"starttime"`
+	FinishTime time.Time `json:"finishtime"`
+}
+
+// Decompress command information
+func (cmd *Command) Decompress() error {
+	err := cmd.DecompressAction()
+	if err != nil {
+		return err
+	}
+	err = cmd.DecompressResult()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Given a command, decompress the action information if it is compressed
+func (cmd *Command) DecompressAction() error {
+	if len(cmd.CompressedAction) == 0 {
+		// Action is not compressed, ignore
+		return nil
+	}
+	r, err := gzip.NewReader(bytes.NewBuffer(cmd.CompressedAction))
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(data, &cmd.Action)
+	if err != nil {
+		return err
+	}
+	cmd.CompressedAction = nil
+	return nil
+}
+
+// Given a command, decompress the result information if it is compressed
+func (cmd *Command) DecompressResult() error {
+	if len(cmd.CompressedResults) == 0 {
+		return nil
+	}
+	cmd.Results = make([]modules.Result, len(cmd.CompressedResults))
+	for i := range cmd.CompressedResults {
+		r, err := gzip.NewReader(bytes.NewBuffer(cmd.CompressedResults[i]))
+		if err != nil {
+			return err
+		}
+		data, err := ioutil.ReadAll(r)
+		if err != nil {
+			r.Close()
+			return err
+		}
+		err = json.Unmarshal(data, &cmd.Results[i])
+		if err != nil {
+			r.Close()
+			return err
+		}
+		cmd.CompressedResults[i] = nil
+		r.Close()
+	}
+	return nil
+}
+
+// Compress command information
+func (cmd *Command) Compress() error {
+	err := cmd.CompressAction()
+	if err != nil {
+		return err
+	}
+	err = cmd.CompressResult()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Given a command, compress the action information stored in the command
+func (cmd *Command) CompressAction() error {
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	nb, err := json.Marshal(cmd.Action)
+	if err != nil {
+		return err
+	}
+	w.Write(nb)
+	w.Close()
+	cmd.CompressedAction = b.Bytes()
+	cmd.Action = Action{}
+	return nil
+}
+
+// Given a command, compress the result information stored in the command
+func (cmd *Command) CompressResult() error {
+	if len(cmd.Results) == 0 {
+		return nil
+	}
+	cmd.CompressedResults = make([][]byte, len(cmd.Results))
+	for i := range cmd.Results {
+		var b bytes.Buffer
+		w := gzip.NewWriter(&b)
+		nb, err := json.Marshal(cmd.Results[i])
+		if err != nil {
+			return err
+		}
+		w.Write(nb)
+		w.Close()
+		cmd.CompressedResults[i] = b.Bytes()
+		cmd.Results[i] = modules.Result{}
+	}
+	return nil
 }
 
 const (
@@ -56,6 +181,11 @@ func CmdFromFile(path string) (cmd Command, err error) {
 		panic(err)
 	}
 	err = json.Unmarshal(jsonCmd, &cmd)
+	if err != nil {
+		panic(err)
+	}
+	// Perform any required decompression on the command
+	err = cmd.Decompress()
 	if err != nil {
 		panic(err)
 	}

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -472,6 +472,13 @@ func parseCommands(ctx Context, msg []byte) (err error) {
 		panic(err)
 	}
 
+	// If required, decompress the action before we validate the signature
+	// on the message.
+	err = cmd.Decompress()
+	if err != nil {
+		panic(err)
+	}
+
 	// verify the PGP signature of the action, and verify that
 	// the signer is authorized to perform this action
 	err = checkActionAuthorization(cmd.Action, ctx)
@@ -704,6 +711,10 @@ func sendResults(ctx Context, result mig.Command) (err error) {
 	}()
 	ctx.Channels.Log <- mig.Log{CommandID: result.ID, ActionID: result.Action.ID, Desc: "sending command results"}
 	result.Agent.QueueLoc = ctx.Agent.QueueLoc
+	err = result.Compress()
+	if err != nil {
+		panic(err)
+	}
 	body, err := json.Marshal(result)
 	if err != nil {
 		panic(err)

--- a/mig-scheduler/routines.go
+++ b/mig-scheduler/routines.go
@@ -197,6 +197,11 @@ func startRoutines(ctx Context) {
 				continue
 			}
 			// write to disk in Returned directory, discard and continue on failure
+			//
+			// Note: It is possible data returned by the agent (e.g., a command) has
+			// components of the document that have been compressed. Any routines loading
+			// data from these files should ensure decompression happens as part of the
+			// loading process.
 			dest := fmt.Sprintf("%s/%.0f", ctx.Directories.Command.Returned, ctx.OpID)
 			err = safeWrite(ctx, dest, delivery.Body)
 			if err != nil {

--- a/mig-scheduler/scheduler.go
+++ b/mig-scheduler/scheduler.go
@@ -211,6 +211,16 @@ func sendCommands(cmds []mig.Command, ctx Context) (err error) {
 		if err != nil {
 			panic(err)
 		}
+		// After the command has been written to the spool, apply compression to the
+		// command; this requires compressing and remarshaling it
+		err = cmd.Compress()
+		if err != nil {
+			panic(err)
+		}
+		data, err = json.Marshal(cmd)
+		if err != nil {
+			panic(err)
+		}
 		// send amqp message with an expiration timer
 		expire := cmd.Action.ExpireAfter.Sub(cmd.Action.ValidFrom)
 		msg := amqp.Publishing{


### PR DESCRIPTION
Initial PR for addition of command compression between agents and the scheduler

Note: this breaks compatibility with older agent versions currently. One option is to make compression an option, maybe based on the agent environment (known capabilities) or, an option in the action/command.