### PR TITLE
[medium] [module] Account module for looking up user activity

### DIFF
--- a/conf/available_modules.go
+++ b/conf/available_modules.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	_ "mig.ninja/mig/modules/account"
 	_ "mig.ninja/mig/modules/agentdestroy"
 	_ "mig.ninja/mig/modules/file"
 	_ "mig.ninja/mig/modules/memory"

--- a/modules/account/account.go
+++ b/modules/account/account.go
@@ -1,0 +1,215 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Kishor Bhat kishorbhat@gmail.com [:kbhat]
+
+package account /* import "mig.ninja/mig/modules/account" */
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mig.ninja/mig/modules"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var debug bool = false
+
+func debugprint(format string, a ...interface{}) {
+	if debug {
+		fmt.Fprintf(os.Stderr, format, a...)
+	}
+}
+
+type module struct {
+}
+
+func (m *module) NewRun() modules.Runner {
+	return new(run)
+}
+
+func init() {
+	modules.Register("account", new(module))
+}
+
+type run struct {
+	Parameters params
+	Results    modules.Result
+}
+
+type params struct {
+	Group string `json:"group"`
+	User  string `json:"user"`
+}
+
+type elements struct {
+	FoundUser  bool `json:"founduser"`  // true if user is found, false otherwise
+	FoundGroup bool `json:"foundgroup"` // true if group is found, false otherwise
+}
+
+func (r *run) ValidateParameters() (err error) {
+	debugprint("validating user '%s'\n", r)
+	err = validateName(r.Parameters.User)
+	if err != nil {
+		return fmt.Errorf("ERRROR: %v\n", err)
+	}
+	debugprint("validating group '%s'\n", r)
+	err = validateName(r.Parameters.Group)
+	if err != nil {
+		return fmt.Errorf("ERROR: %v\n", err)
+	}
+	return
+}
+
+func validateName(name string) error {
+	if len(name) < 1 {
+		return fmt.Errorf("Empty names are not permitted")
+	}
+	nameregexp := `^[_a-z][-0-9_a-z]*\$?`
+	namere := regexp.MustCompile(nameregexp)
+	if !namere.MatchString(name) {
+		return fmt.Errorf("The syntax of name '%s' is invalid, and must match regex %s", name, nameregexp)
+	}
+	return nil
+}
+
+func (r *run) Run(in io.Reader) (out string) {
+	var (
+		el  elements
+		err error
+	)
+	defer func() {
+		if e := recover(); e != nil {
+			r.Results.Errors = append(r.Results.Errors, fmt.Sprintf("%v", e))
+			r.Results.Success = false
+			buf, _ := json.Marshal(r.Results)
+			out = string(buf[:])
+		}
+	}()
+	err = modules.ReadInputParameters(in, &r.Parameters)
+	if err != nil {
+		panic(err)
+	}
+	err = r.ValidateParameters()
+	if err != nil {
+		panic(err)
+	}
+	if r.Parameters.User != "" {
+		el.FoundUser, err = r.FindUser()
+		if err != nil {
+			return
+		}
+	}
+	if r.Parameters.Group != "" {
+		el.FoundGroup, err = r.FindGroup()
+		if err != nil {
+			return
+		}
+	}
+	return r.buildResults(el)
+}
+
+// FindUser opens up /etc/passwd, and reads each line.
+// If the supplied username is found, the user exists.
+func (r *run) FindUser() (found bool, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("FindUser(): %v", e)
+		}
+	}()
+	file, err := os.Open("/etc/passwd")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		uname := strings.SplitN(scanner.Text(), ":", 2)[0]
+		found = strings.Contains(uname, r.Parameters.User)
+		if found == true {
+			break
+		}
+	}
+	return
+}
+
+// FindGroup opens up /etc/group, and reads each line.
+// If the supplied groupname is found, the user exists.
+func (r *run) FindGroup() (found bool, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("FindGroup(): %v", e)
+		}
+	}()
+	file, err := os.Open("/etc/group")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		gname := strings.SplitN(scanner.Text(), ":", 2)[0]
+		found = strings.Contains(gname, r.Parameters.Group)
+		if found == true {
+			break
+		}
+	}
+	return
+}
+
+func (r *run) buildResults(el elements) string {
+	r.Results.Elements = el
+	if len(r.Results.Errors) == 0 {
+		r.Results.Success = true
+	}
+	jsonOutput, err := json.Marshal(r.Results)
+	if err != nil {
+		panic(err)
+	}
+	return string(jsonOutput[:])
+}
+
+func (r *run) PrintResults(result modules.Result, foundOnly bool) (prints []string, err error) {
+	var el elements
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("Print Error: %v", e)
+		}
+	}()
+	err = result.GetElements(&el)
+	if err != nil {
+		panic(err)
+	}
+	var phrase string
+	if r.Parameters.User != "" {
+		switch el.FoundUser {
+		case true:
+			phrase = "found"
+		default:
+			phrase = "not found"
+		}
+		prints = append(prints,
+			fmt.Sprintf("User %s %s.", r.Parameters.User, phrase))
+	}
+	if r.Parameters.Group != "" {
+		switch el.FoundGroup {
+		case true:
+			phrase = "found"
+		default:
+			phrase = "not found"
+		}
+		prints = append(prints,
+			fmt.Sprintf("Group %s %s.", r.Parameters.Group, phrase))
+	}
+
+	if !foundOnly {
+		for _, we := range result.Errors {
+			prints = append(prints, we)
+		}
+	}
+	return
+}

--- a/modules/account/account_test.go
+++ b/modules/account/account_test.go
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Kishor Bhat <kishorbhat@gmail.com>
+
+package account /* import "mig.ninja/mig/modules/account" */
+
+import (
+	"mig.ninja/mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "account")
+}

--- a/modules/account/doc.rst
+++ b/modules/account/doc.rst
@@ -1,0 +1,9 @@
+====================================
+Mozilla InvestiGator: Account module
+====================================
+:Author: Kishor Bhat <kishorbhat@gmail.com>
+
+.. sectnum::
+.. contents:: Table of Contents
+
+The account module aims at providing basic account-related functionality.

--- a/modules/account/paramscreator.go
+++ b/modules/account/paramscreator.go
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Kishor Bhat kishorbhat@gmail.com [:kbhat]
+
+package account /* import "mig.ninja/mig/modules/account" */
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func printHelp(isCmd bool) {
+	dash := ""
+	if isCmd {
+		dash = "-"
+	}
+	fmt.Printf(`Query parameters
+----------------
+%scheckuser <username> - check whether given user exists on system
+			ex: checkuser john
+
+%scheckgroup <groupname>  - check whether given group exists on system
+			ex: checkgroup docker
+`, dash, dash)
+
+	return
+}
+
+// ParamsCreator implements an interactive interface for the console
+// It takes a string and returns a params structure in an interface
+func (r *run) ParamsCreator() (interface{}, error) {
+	var (
+		err error
+		p   params
+	)
+	scanner := bufio.NewScanner(os.Stdin)
+	p.User = ""
+	p.Group = ""
+	for {
+		fmt.Printf("account> ")
+		scanmore := scanner.Scan()
+		if err := scanner.Err(); err != nil {
+			fmt.Println("Invalid input. Try again")
+			continue
+		}
+		if !scanmore {
+			goto exit
+		}
+		input := scanner.Text()
+		if input == "done" {
+			goto exit
+		} else if input == "help" {
+			printHelp(false)
+			continue
+		}
+		arr := strings.SplitN(input, " ", 2)
+		if len(arr) != 2 {
+			fmt.Printf("Invalid input format!\n")
+			printHelp(false)
+			continue
+		}
+		option := arr[0]
+		checkValue := arr[1]
+		switch option {
+		case "checkuser":
+			if checkValue == "" {
+				fmt.Println("Missing parameter, try again")
+				continue
+			}
+			err = validateName(checkValue)
+			if err != nil {
+				fmt.Printf("ERROR: %v\nTry again.\n", err)
+				continue
+			}
+			p.User = checkValue
+		case "checkgroup":
+			if checkValue == "" {
+				fmt.Println("Missing parameter, try again")
+				continue
+			}
+			err = validateName(checkValue)
+			if err != nil {
+				fmt.Printf("ERROR: %v\nTry again.\n", err)
+				continue
+			}
+			p.Group = checkValue
+		default:
+			fmt.Printf("Invalid method!\nTry 'help'\n")
+			continue
+		}
+	}
+
+exit:
+	r.Parameters = p
+	return r.Parameters, r.ValidateParameters()
+}
+
+// ParamsParser implements a commandline parameter parser for the account module
+func (r *run) ParamsParser(args []string) (interface{}, error) {
+	var (
+		err         error
+		p           params
+		user, group string
+		fs          flag.FlagSet
+	)
+
+	if len(args) < 1 || args[0] == "" || args[0] == "help" {
+		printHelp(true)
+		return nil, nil
+	}
+
+	fs.Init("account", flag.ContinueOnError)
+	fs.StringVar(&user, "user", "", "see help")
+	fs.StringVar(&group, "group", "", "see help")
+	err = fs.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+	p.User = user
+	p.Group = group
+	r.Parameters = p
+	return r.Parameters, r.ValidateParameters()
+}


### PR DESCRIPTION
This is in reference to #100, and is still a work in progress.
So far, the "check user/group on system" aspect has been tackled with.
I thought I'd raise a PR early so that I can correct any mistakes and/or
incorrect assumptions sooner rather than later.

For ongoing progress (and as a note to self):
- [X] check if user/group is present on system
- [X] ~~create and disable accounts~~ (makes more sense to move this to a new module, see below)
- [X] ~~compare hash string with current password~~ (avoiding this due to violation of the "don't extract data" policy)
- [ ] check when a user last logged in -- this can be done by parsing `/var/log/auth.log` for `sshd` and `systemd-logind` entries
- [ ] documentation!
