### PR TITLE
fixes to scheduler

### DIFF
--- a/mig-scheduler/agents_queues.go
+++ b/mig-scheduler/agents_queues.go
@@ -133,9 +133,9 @@ func getHeartbeats(msg amqp.Delivery, ctx Context) (err error) {
 			}
 		} else {
 			// the agent exists in database. reuse the existing ID, and keep the status if it was
-			// previously set to destroyed or upgraded. otherwise set status to online
+			// previously set to destroyed, otherwise set status to online
 			agt.ID = agent.ID
-			if agent.Status == mig.AgtStatusDestroyed || agent.Status == mig.AgtStatusUpgraded {
+			if agt.Status == mig.AgtStatusDestroyed {
 				agt.Status = agent.Status
 			} else {
 				agt.Status = mig.AgtStatusOnline

--- a/mig-scheduler/routines.go
+++ b/mig-scheduler/routines.go
@@ -267,18 +267,16 @@ func startRoutines(ctx Context) {
 	ctx.Channels.Log <- mig.Log{Desc: "queue cleanup routine started"}
 
 	// launch the routine that handles multi agents on same queue
-	if ctx.Agent.KillDupAgents {
-		go func() {
-			for queueLoc := range ctx.Channels.DetectDupAgents {
-				ctx.OpID = mig.GenID()
-				err = killDupAgents(queueLoc, ctx)
-				if err != nil {
-					ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("%v", err)}.Err()
-				}
+	go func() {
+		for queueLoc := range ctx.Channels.DetectDupAgents {
+			ctx.OpID = mig.GenID()
+			err = killDupAgents(queueLoc, ctx)
+			if err != nil {
+				ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("%v", err)}.Err()
 			}
-		}()
-		ctx.Channels.Log <- mig.Log{Desc: "killDupAgents() routine started"}
-	}
+		}
+	}()
+	ctx.Channels.Log <- mig.Log{Desc: "killDupAgents() routine started"}
 
 	// launch the routine that heartbeats the relays and terminates if connection is lost
 	go func() {

--- a/mig-scheduler/scheduler.go
+++ b/mig-scheduler/scheduler.go
@@ -306,15 +306,6 @@ func updateAction(cmds []mig.Command, ctx Context) (err error) {
 
 		// store action in the map
 		actions[a.ID] = a
-
-		// slightly unrelated to updating the action:
-		// in case the action is about upgrading agents, do some magical stuff
-		// to continue the upgrade protocol
-		if cmd.Status == mig.StatusSuccess && len(a.Operations) > 0 {
-			if a.Operations[0].Module == "upgrade" {
-				go markUpgradedAgents(cmd, ctx)
-			}
-		}
 	}
 	for _, a := range actions {
 		a.Counters, err = ctx.DB.GetActionCounters(a.ID)


### PR DESCRIPTION
Removes upgrade module code in the scheduler.

Ensure we drain DetectDupAgents even if the option to kill duplicate agents is disabled in the scheduler configuration. There are a few places in the code we write to this channel, currently if the option is disabled the receiving end will not be spawned. This leads to routines in the scheduler blocking when they write here. We already check the configuration in the agent kill function in the scheduler, so just drain the channel and call this function and it is handled there depending on the setting.