### PR TITLE
Minor improvements to loader API authentication

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -277,6 +277,12 @@ func (cli Client) Do(r *http.Request) (resp *http.Response, err error) {
 	// if the request failed because of an auth issue, it may be that the auth token has expired.
 	// try the request again with a fresh token
 	if resp.StatusCode == http.StatusUnauthorized {
+		// Make sure we read the entire response body from the previous request before we close it
+		// to avoid connection cancellation issues and a panic in API.Do()
+		_, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			panic(err)
+		}
 		resp.Body.Close()
 		cli.Token, err = cli.MakeSignedToken()
 		if err != nil {

--- a/loader.go
+++ b/loader.go
@@ -7,6 +7,8 @@
 package mig /* import "mig.ninja/mig" */
 
 import (
+	"errors"
+	"regexp"
 	"time"
 )
 
@@ -21,5 +23,13 @@ type LoaderEntry struct {
 }
 
 func (le *LoaderEntry) Validate() error {
+	return nil
+}
+
+func ValidateLoaderKey(key string) error {
+	ok, err := regexp.MatchString("^[A-Za-z0-9]{1,256}$", key)
+	if err != nil || !ok {
+		return errors.New("loader key format is invalid")
+	}
 	return nil
 }

--- a/mig-api/api.go
+++ b/mig-api/api.go
@@ -222,6 +222,10 @@ func authenticate(pass handler, adminRequired bool) handler {
 			if !inv.IsAdmin {
 				inv.Name = "authfailed"
 				inv.ID = -1
+				ctx.Channels.Log <- mig.Log{
+					OpID: getOpID(r),
+					Desc: fmt.Sprintf("Investigator '%v' %v has insufficient privileges to access API function", getInvName(r), getInvID(r)),
+				}.Info()
 				resource := cljs.New(fmt.Sprintf("%s%s", ctx.Server.Host, r.URL.String()))
 				resource.SetError(cljs.Error{Code: fmt.Sprintf("%.0f", opid),
 					Message: "Insufficient privileges"})

--- a/mig-api/api.go
+++ b/mig-api/api.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"regexp"
 	"runtime"
 	"strings"
 
@@ -258,11 +257,11 @@ func authenticateLoader(pass handler) handler {
 		}
 		// Do a sanity check here on the submitted loader string before
 		// we attempt the authentication
-		lkeyok, err := regexp.MatchString("[A-Za-z0-9]{1,256}", lkey)
-		if err == nil && lkeyok {
+		err = mig.ValidateLoaderKey(lkey)
+		if err == nil {
 			loaderid, err = ctx.DB.GetLoaderEntryID(lkey)
 		}
-		if err != nil || !lkeyok {
+		if err != nil {
 			resource := cljs.New(fmt.Sprintf("%s%s", ctx.Server.Host, r.URL.String()))
 			resource.SetError(cljs.Error{Code: fmt.Sprintf("%.0f", opid), Message: fmt.Sprintf("Loader authorization failed")})
 			respond(http.StatusUnauthorized, resource, w, r)

--- a/mig-loader/loader.go
+++ b/mig-loader/loader.go
@@ -544,7 +544,12 @@ func loadLoaderKey() error {
 		}
 		return err
 	}
-	LOADERKEY = string(buf)
+	// Also trim any leading and trailing spaces from the loader key
+	LOADERKEY = strings.Trim(string(buf), " ")
+	err = mig.ValidateLoaderKey(LOADERKEY)
+	if err != nil {
+		return err
+	}
 	ctx.LoaderKey = LOADERKEY
 	return nil
 }


### PR DESCRIPTION
This also resolves an issue in the client library on 401 re-request where the body was not being read prior to submitting the request again.