### PR TITLE
Remove per-loader relay credentials

### DIFF
--- a/client/mig-console/manifest.go
+++ b/client/mig-console/manifest.go
@@ -89,6 +89,8 @@ help            show this help
 
 exit            exit this mode (also works with ctrl+d)
 
+fetch           fetch manifest content and save to disk
+
 json            show json of manifest record stored in database
 
 loaders         show known loader entries that will match this manifest
@@ -102,6 +104,15 @@ sign            add a signature to the manifest record
 		case "exit":
 			fmt.Printf("exit\n")
 			goto exit
+		case "fetch":
+			if len(orders) != 2 {
+				fmt.Println("error: must be 'fetch <path>'. try 'help'")
+				break
+			}
+			err = mr.FileFromContent(orders[1])
+			if err != nil {
+				panic(err)
+			}
 		case "json":
 			tmpmr := mr
 			if len(tmpmr.Content) > 0 {

--- a/doc/loader.rst
+++ b/doc/loader.rst
@@ -187,28 +187,6 @@ If a file is not present in a manifest, it will not be deployed with the loader.
 example, you may not want a configuration file to be part of the manifest if you
 want to deploy agents with a built-in configuration.
 
-The configuration file deployed using mig-loader needs to differ slightly from
-the configuration file you would use otherwise. Within the configuration file in
-the manifest, the AMQP relay URL should not have a username and password. When
-mig-loader installs the configuration file on and endpoint, it will automatically
-add the loader name and loader key (discussed later) as the AMQP username and
-password to use. This allows for different credentials per endpoint to connect
-to the relay, and provides an ability to isolate an agent from connecting if
-needed which would not be possible with a shared credential.
-
-Instead of putting the credentials in the configuration file, your relay configuration
-line should look something like this.
-
-::
-
-    relay = "amqps://<<AMQPCRED>>@my.mig.relay.url:5671/mig"
-
-<<AMQPCRED>> will be replaced on the endpoint with whatever credentials that
-endpoint should be using to connect to the relay.
-
-**Note:** If you want a built-in configuration, you will not be able to do per-agent
-relay credentials (all agents will connect with the same AMQP username and password).
-
 To create a manifest, create a directory we will use to place the files we want
 to be in the manifest. Copy the components into the directory you want to be part
 of the manifest. The components must have specific file names representing their
@@ -379,27 +357,6 @@ used.
 Note the agent name is unset as it has not been used yet. Once mig-loader connects
 and authenticates as this loader instance, it will be populated with the hostname of
 the device.
-
-Adding the new instance to the relay
-------------------------------------
-The loader instance configured using mig-console allows authentication with the
-API. We also need to add the credentials to RabbitMQ, as they will also be used by
-the loader provisioned agent to connect. This was mentioned previously with respect
-to using AMQPCRED in the agent configuration file.
-
-Add a new user to the MIG RabbitMQ vhost with the same key used for the loader
-instance. Ensure the correct permissions are set on the new RabbitMQ user. You
-can use ``rabbitmqctl`` for this, or use the RabbitMQ admin interface.
-
-The following example shows how you would add a user and set the required
-permissions on your relay, using ``rabbitmqctl``.
-
-::
-
-    # rabbitmqctl add_user corbomite.internal vw1NQs9F3wuZx1kSUhZaQzZ0
-    Creating user "corbomite.internal" ...
-    # rabbitmqctl set_permissions -p mig corbomite.internal '^mig\.agt\..*$' '^(toschedulers|mig\.agt\..*)$' '^(toagents|mig\.agt\..*)$'
-    Setting permissions for user "corbomite.internal" in vhost "mig" ...
 
 Initial provisioning of mig-loader
 ----------------------------------

--- a/manifest.go
+++ b/manifest.go
@@ -218,6 +218,26 @@ func (m *ManifestRecord) ContentFromFile(path string) (err error) {
 	return
 }
 
+// Write manifest content to a file on the file system
+func (m *ManifestRecord) FileFromContent(path string) (err error) {
+	fd, err := os.Create(path)
+	if err != nil {
+		return
+	}
+	defer fd.Close()
+	bufr := bytes.NewBufferString(m.Content)
+	b64r := base64.NewDecoder(base64.StdEncoding, bufr)
+	b, err := ioutil.ReadAll(b64r)
+	if err != nil {
+		return
+	}
+	_, err = fd.Write(b)
+	if err != nil {
+		return
+	}
+	return nil
+}
+
 // Manifest parameters are sent from the loader to the API as part of
 // a manifest request.
 type ManifestParameters struct {


### PR DESCRIPTION
This removes support for the per-loader relay credentials, and functions that transform the agent configuration file. The configuration file is treated like the other objects in the manifest now. The reduces the complexity associated with deploying the loader, as the cost of having a shared credential for rabbitMQ amongst agents deployed using the manifest.

This also adds support for fetching the manifest for review using mig-console.