### PR TITLE
[medium] change agent proxy behavior to prefer proxies

### DIFF
--- a/conf/mig-agent-conf.go.inc
+++ b/conf/mig-agent-conf.go.inc
@@ -59,7 +59,10 @@ var APIURL string = "http://localhost:1664/api/v1/"
 
 // if the connection still fails after looking for a HTTP_PROXY, try to use the
 // proxies listed below
-var PROXIES = [...]string{`proxy.example.net:3128`, `proxy2.example.net:8080`}
+var PROXIES = []string{"proxy.example.net:3128", "proxy2.example.net:8080"}
+// If you don't want proxies in the built-in configuration, use the following
+// instead.
+// var PROXIES = []string{}
 
 // local socket used to retrieve stat information from a running agent
 var SOCKET = "127.0.0.1:51664"

--- a/conf/mig-agent.cfg.inc
+++ b/conf/mig-agent.cfg.inc
@@ -20,6 +20,11 @@
     ; will attempt to restart itself instead of just shutting down
     isimmortal       = on
 
+    ; comma delimited list of host:port proxies to use, if desired
+    ; the agent will attempt to try to proxies for public ip retrieval
+    ; and the relay connection before a direct connection
+    ; proxies          = "proxy1:8888,proxy2:8888"
+
     ; installservice orders the agent to deploy a service init configuration
     ; and start itself during the endpoint's boot process
     installservice   = on

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -856,11 +856,13 @@ public IP during startup.
 Proxy support
 ~~~~~~~~~~~~~
 
-The agent supports connecting to the relay via a CONNECT proxy. It will attempt
-a direct connection first, and if this fails, will look for the environment
-variable `HTTP_PROXY` to use as a proxy. A list of proxies can be manually
-added to the configuration of the agent in the `PROXIES` parameters. These
-proxies will be used if the two previous connections fail.
+The agent supports connecting to the relay via a CONNECT proxy. If proxies are
+configured, it will attempt to use them before attemping a direct connection. The
+agent will also attempt to use any proxy noted in the environment via the
+`HTTP_PROXY` environment variable. A list of proxies can be manually
+added to the configuration of the agent in the `PROXIES` parameters. Proxies can
+also be specified in the agent configuration file, and will override any built-in
+configuration.
 
 An agent using a proxy will reference the name of the proxy in the environment
 fields of the heartbeat sent to the scheduler.
@@ -1635,7 +1637,6 @@ The following parameters are **not** controlable by the configuration file:
 
 * list of investigators public keys in `PUBLICPGPKEYS`
 * list of access control lists in `AGENTACL`
-* list of proxies in `PROXIES`
 
 All other parameters can be overriden in the configuration file. Check out the
 sample file `mig-agent.cfg.inc` in the **conf** folder.

--- a/mig-agent/config.go
+++ b/mig-agent/config.go
@@ -9,6 +9,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"time"
 
 	"mig.ninja/mig"
@@ -23,6 +24,7 @@ type config struct {
 		DiscoverPublicIP bool
 		DiscoverAWSMeta  bool
 		CheckIn          bool
+		Proxies          string
 		Relay            string
 		Socket           string
 		HeartbeatFreq    string
@@ -80,6 +82,9 @@ func configLoad(path string) (err error) {
 	MUSTINSTALLSERVICE = config.Agent.InstallService
 	DISCOVERPUBLICIP = config.Agent.DiscoverPublicIP
 	DISCOVERAWSMETA = config.Agent.DiscoverAWSMeta
+	if config.Agent.Proxies != "" {
+		PROXIES = strings.Split(config.Agent.Proxies, ",")
+	}
 	CHECKIN = config.Agent.CheckIn
 	LOGGINGCONF = config.Logging
 	AMQPBROKER = config.Agent.Relay

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -302,7 +302,7 @@ var LOGGINGCONF = mig.Logging{
     File:   "/var/cache/mig/mig-agent.log",
 }
 var AMQPBROKER string = "amqp://agent:$mqpass@localhost:5672/mig"
-var PROXIES = [...]string{``}
+var PROXIES = []string{}
 var SOCKET string = "127.0.0.1:51664"
 var HEARTBEATFREQ time.Duration = 30 * time.Second
 var REFRESHENV time.Duration = 60 * time.Second


### PR DESCRIPTION
If any proxies have been configured, try those first before attempting
direct connections. This also adds specifying proxies in the agent
config file, where as before they were only compile time options in the
built-in configuration.

Resolves #249