### PR TITLE
[minor] add support for user defined target macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
     - make
     - yes | bash tools/standalone_install.sh
     - ./bin/linux/amd64/mig-agent-latest -i actions/example_v2.json
-    - ./bin/linux/amd64/mig scribe -z -path actions/scribe/usn-2015.json -onlytrue -human
+    - ./bin/linux/amd64/mig scribe -t status='online' -z -path actions/scribe/usn-2015.json -onlytrue -human

--- a/client/macro.go
+++ b/client/macro.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package client /* import "mig.ninja/mig/client" */
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Parse macros specified in the client configuration for use in the client
+func addTargetMacros(conf *Configuration) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("addTargetMacros() -> %v", e)
+		}
+	}()
+
+	for _, x := range conf.Targets.Macro {
+		iv := strings.Index(x, ":")
+		if iv < 1 {
+			es := fmt.Sprintf("Invalid macro format: %q", x)
+			panic(es)
+		}
+		name := x[:iv]
+		tgt := x[iv+1:]
+		conf.Targets.addMacro(name, tgt)
+	}
+
+	return nil
+}

--- a/client/mig-console/action_launcher.go
+++ b/client/mig-console/action_launcher.go
@@ -331,6 +331,9 @@ times			show the various timestamps of the action
 				break
 			}
 			a.Target = strings.Join(orders[1:], " ")
+			// Convert the target string to the desired value if the input was a
+			// target macro
+			a.Target = cli.ResolveTargetMacro(a.Target)
 			agents, err := cli.EvaluateAgentTarget(a.Target)
 			if err != nil {
 				fmt.Println(err)

--- a/client/mig/main.go
+++ b/client/mig/main.go
@@ -275,7 +275,7 @@ func main() {
 		target = targetQuery + " AND " + target
 	}
 	if targetnotfound != "" {
-		targetQuery := fmt.Sprintf(`id NOT IN (select agentid from commands, json_array_elements(commands.results) as `+
+		targetQuery := fmt.Sprintf(`id IN (select agentid from commands, json_array_elements(commands.results) as `+
 			`r where actionid=%s and r#>>'{foundanything}' = 'false')`, targetnotfound)
 		target = targetQuery + " AND " + target
 	}

--- a/client/mig/main.go
+++ b/client/mig/main.go
@@ -52,8 +52,8 @@ usage: %s <module> <global options> <module parameters>
 		* run on local system:	 -t local
 		* use a migrc macro:     -t mymacroname
 
--targetfound <action ID>
--targetnotfound <action ID>
+-target-found    <action ID>
+-target-notfound <action ID>
 		targets agents that have eiher found or not found results in a previous action.
 		example: -target-found 123456
 

--- a/conf/migrc.inc
+++ b/conf/migrc.inc
@@ -11,3 +11,10 @@
 
     # pgp fingerprint of the investigator
     keyid = "E60892BB9BD89A69F759A1A0A3D652173B763E8F"
+
+# the targets section lets you define custom user macros you can use as an
+# argument to the -t flag with mig, or settargets in mig-console rather
+# than having to specify a full targeting string.
+#[targets]
+#    macro = all:status='online'
+#    macro = onlineandidle:status='online' OR status='idle'

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -670,6 +670,13 @@ you can reuse with your own values.
 	[gpg]
 		home = "/home/myuser/.gnupg/"
 		keyid = "E60892BB9BD89A69F759A1A0A3D652173B763E8F"
+        [targets]
+                macro = allonline:status='online'
+                macro = idleandonline:status='online' OR status='idle'
+
+The targets section is optional and provides the ability to specify
+short forms of your own targeting strings. In the example above, 
+`allonline` or `idleandonline` could be used as target arguments.
 
 Make sure have the dev library of readline installed (`readline-devel` on
 rhel/fedora or `libreadline-dev` on debian/ubuntu) and `go get` the binary from

--- a/doc/console.rst
+++ b/doc/console.rst
@@ -203,7 +203,8 @@ Action parameters can be edited prior to launching it:
 
 	launcher> setname Test action that pings google.com
 
-* **settarget** sets the target of the action. The target is evaluated
+* **settarget** sets the target of the action. Targets can either be a targeting
+  string, or a macro if defined in migrc. The target is evaluated
   right away, and a list of targeted agents can be obtained via **listagents**::
 
 	launcher> settarget environment->>'os'='linux' and mode='daemon'


### PR DESCRIPTION
This provides the ability for users to define target macros in ~/.migrc,
as an example rather than requiring -t "status='online'", given a
section such as:

[targets]
    macro = allonline:status='online'

in .migrc, you can then do -t allonline. The intended specification
format is macro = name:target string. Multiple "macro" items can be
specified in the targets section.