### PR TITLE
[medium] more granular permissions for investigators

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -961,7 +961,7 @@ func (cli Client) GetInvestigator(iid float64) (inv mig.Investigator, err error)
 }
 
 // PostInvestigator creates an Investigator and returns the reflected investigator
-func (cli Client) PostInvestigator(name string, pubkey []byte, isadmin bool) (inv mig.Investigator, err error) {
+func (cli Client) PostInvestigator(name string, pubkey []byte, perms int) (inv mig.Investigator, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("PostInvestigator() -> %v", e)
@@ -975,7 +975,7 @@ func (cli Client) PostInvestigator(name string, pubkey []byte, isadmin bool) (in
 	if err != nil {
 		panic(err)
 	}
-	err = writer.WriteField("isadmin", fmt.Sprintf("%v", isadmin))
+	err = writer.WriteField("permissions", fmt.Sprintf("%v", perms))
 	if err != nil {
 		panic(err)
 	}
@@ -1025,14 +1025,14 @@ func (cli Client) PostInvestigator(name string, pubkey []byte, isadmin bool) (in
 	return
 }
 
-// PostInvestigatorAdminFlag enables or disabled admin status for an investigator
-func (cli Client) PostInvestigatorAdminFlag(iid float64, enabled bool) (err error) {
+// PostInvestigatorPerms sets permission on an investigator
+func (cli Client) PostInvestigatorPerms(iid float64, perm int) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = fmt.Errorf("PostInvestigatorAdminFlag() -> %v", e)
+			err = fmt.Errorf("PostInvestigatorPerms() -> %v", e)
 		}
 	}()
-	data := url.Values{"id": {fmt.Sprintf("%.0f", iid)}, "isadmin": {fmt.Sprintf("%v", enabled)}}
+	data := url.Values{"id": {fmt.Sprintf("%.0f", iid)}, "permissions": {fmt.Sprintf("%v", perm)}}
 	r, err := http.NewRequest("POST", cli.Conf.API.URL+"investigator/update/", strings.NewReader(data.Encode()))
 	if err != nil {
 		panic(err)
@@ -1055,7 +1055,7 @@ func (cli Client) PostInvestigatorAdminFlag(iid float64, enabled bool) (err erro
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("error: HTTP %d. admin flag update failed with error '%v' (code %s)",
+		err = fmt.Errorf("error: HTTP %d. permission update failed with error '%v' (code %s)",
 			resp.StatusCode, resource.Collection.Error.Message, resource.Collection.Error.Code)
 		panic(err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -961,7 +961,7 @@ func (cli Client) GetInvestigator(iid float64) (inv mig.Investigator, err error)
 }
 
 // PostInvestigator creates an Investigator and returns the reflected investigator
-func (cli Client) PostInvestigator(name string, pubkey []byte, perms int) (inv mig.Investigator, err error) {
+func (cli Client) PostInvestigator(name string, pubkey []byte, pset mig.InvestigatorPerms) (inv mig.Investigator, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("PostInvestigator() -> %v", e)
@@ -975,7 +975,11 @@ func (cli Client) PostInvestigator(name string, pubkey []byte, perms int) (inv m
 	if err != nil {
 		panic(err)
 	}
-	err = writer.WriteField("permissions", fmt.Sprintf("%v", perms))
+	pbuf, err := json.Marshal(&pset)
+	if err != nil {
+		panic(err)
+	}
+	err = writer.WriteField("permissions", string(pbuf))
 	if err != nil {
 		panic(err)
 	}
@@ -1026,13 +1030,17 @@ func (cli Client) PostInvestigator(name string, pubkey []byte, perms int) (inv m
 }
 
 // PostInvestigatorPerms sets permission on an investigator
-func (cli Client) PostInvestigatorPerms(iid float64, perm int) (err error) {
+func (cli Client) PostInvestigatorPerms(iid float64, perm mig.InvestigatorPerms) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("PostInvestigatorPerms() -> %v", e)
 		}
 	}()
-	data := url.Values{"id": {fmt.Sprintf("%.0f", iid)}, "permissions": {fmt.Sprintf("%v", perm)}}
+	permbuf, err := json.Marshal(&perm)
+	if err != nil {
+		panic(err)
+	}
+	data := url.Values{"id": {fmt.Sprintf("%.0f", iid)}, "permissions": {fmt.Sprintf("%v", string(permbuf))}}
 	r, err := http.NewRequest("POST", cli.Conf.API.URL+"investigator/update/", strings.NewReader(data.Encode()))
 	if err != nil {
 		panic(err)

--- a/client/mig-console/search.go
+++ b/client/mig-console/search.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"mig.ninja/mig"
 	"mig.ninja/mig/client"
 	migdbsearch "mig.ninja/mig/database/search"
 )
@@ -125,7 +126,7 @@ No spaces are permitted within parameters. Spaces are used to separate search pa
 	case "command":
 		fmt.Println("----  ID  ---- + ----         Name         ---- + --- Last Updated ---")
 	case "investigator":
-		fmt.Println("- ID - + ----         Name         ---- + --- Status ---")
+		fmt.Println("- ID - + ----         Name         ---- + --- Status --- + -- Permissions ---")
 	case "manifest":
 		fmt.Println("- ID - + ----      Name      ---- + -- Status -- + -------------- Target -------- + ---- Timestamp ---")
 	case "loader":
@@ -200,7 +201,26 @@ No spaces are permitted within parameters. Spaces are used to separate search pa
 				if len(name) > 30 {
 					name = name[0:27] + "..."
 				}
-				fmt.Printf("%6.0f   %s   %s\n", inv.ID, name, inv.Status)
+				sts := inv.Status
+				if len(sts) < 17 {
+					for i := len(sts); i < 16; i++ {
+						sts += " "
+					}
+				}
+				perms := ""
+				for _, x := range mig.InvestigatorPermissions {
+					if (inv.Permissions & x.Value) != 0 {
+						if perms != "" {
+							perms += "," + x.Text
+						} else {
+							perms = x.Text
+						}
+					}
+				}
+				if perms == "" {
+					perms = "InvestigatorOnly"
+				}
+				fmt.Printf("%6.0f   %s   %s %s\n", inv.ID, name, sts, perms)
 			case "manifest":
 				mr, err := client.ValueToManifestRecord(data.Value)
 				if err != nil {

--- a/client/mig-console/search.go
+++ b/client/mig-console/search.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"mig.ninja/mig"
 	"mig.ninja/mig/client"
 	migdbsearch "mig.ninja/mig/database/search"
 )
@@ -126,7 +125,7 @@ No spaces are permitted within parameters. Spaces are used to separate search pa
 	case "command":
 		fmt.Println("----  ID  ---- + ----         Name         ---- + --- Last Updated ---")
 	case "investigator":
-		fmt.Println("- ID - + ----         Name         ---- + --- Status --- + -- Permissions ---")
+		fmt.Println("- ID - + ----         Name         ---- + --- Status ---")
 	case "manifest":
 		fmt.Println("- ID - + ----      Name      ---- + -- Status -- + -------------- Target -------- + ---- Timestamp ---")
 	case "loader":
@@ -207,20 +206,7 @@ No spaces are permitted within parameters. Spaces are used to separate search pa
 						sts += " "
 					}
 				}
-				perms := ""
-				for _, x := range mig.InvestigatorPermissions {
-					if (inv.Permissions & x.Value) != 0 {
-						if perms != "" {
-							perms += "," + x.Text
-						} else {
-							perms = x.Text
-						}
-					}
-				}
-				if perms == "" {
-					perms = "InvestigatorOnly"
-				}
-				fmt.Printf("%6.0f   %s   %s %s\n", inv.ID, name, sts, perms)
+				fmt.Printf("%6.0f   %s   %s\n", inv.ID, name, sts)
 			case "manifest":
 				mr, err := client.ValueToManifestRecord(data.Value)
 				if err != nil {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -102,7 +102,7 @@ CREATE TABLE investigators (
     status          character varying(255) NOT NULL,
     createdat       timestamp with time zone NOT NULL,
     lastmodified    timestamp with time zone NOT NULL,
-    isadmin         boolean NOT NULL DEFAULT false
+    permissions     integer NOT NULL DEFAULT 0
 );
 ALTER TABLE public.investigators OWNER TO migadmin;
 ALTER TABLE ONLY investigators
@@ -203,11 +203,11 @@ GRANT USAGE ON SEQUENCE investigators_id_seq TO migscheduler;
 
 -- API has limited permissions, and cannot list scheduler private keys in the investigators table, but can update their statuses
 GRANT SELECT ON actions, agents, agents_stats, agtmodreq, commands, invagtmodperm, loaders, manifests, manifestsig, modules, signatures TO migapi;
-GRANT SELECT (id, name, pgpfingerprint, publickey, status, createdat, lastmodified, isadmin) ON investigators TO migapi;
+GRANT SELECT (id, name, pgpfingerprint, publickey, status, createdat, lastmodified, permissions) ON investigators TO migapi;
 GRANT INSERT ON actions, signatures, manifests, manifestsig, loaders TO migapi;
 GRANT DELETE ON manifestsig TO migapi;
-GRANT INSERT (name, pgpfingerprint, publickey, status, createdat, lastmodified, isadmin) ON investigators TO migapi;
-GRANT UPDATE (isadmin, status, lastmodified) ON investigators TO migapi;
+GRANT INSERT (name, pgpfingerprint, publickey, status, createdat, lastmodified, permissions) ON investigators TO migapi;
+GRANT UPDATE (permissions, status, lastmodified) ON investigators TO migapi;
 GRANT UPDATE (name, env, tags, loaderkey, salt, lastseen, enabled, expectenv) ON loaders TO migapi;
 GRANT UPDATE (status) ON manifests TO migapi;
 GRANT USAGE ON SEQUENCE investigators_id_seq TO migapi;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -102,7 +102,7 @@ CREATE TABLE investigators (
     status          character varying(255) NOT NULL,
     createdat       timestamp with time zone NOT NULL,
     lastmodified    timestamp with time zone NOT NULL,
-    permissions     integer NOT NULL DEFAULT 0
+    permissions     bigint NOT NULL DEFAULT 0
 );
 ALTER TABLE public.investigators OWNER TO migadmin;
 ALTER TABLE ONLY investigators

--- a/database/searches.go
+++ b/database/searches.go
@@ -847,12 +847,16 @@ func (db *DB) SearchInvestigators(p search.Parameters) (investigators []mig.Inve
 		return
 	}
 	for rows.Next() {
-		var inv mig.Investigator
-		err = rows.Scan(&inv.ID, &inv.Name, &inv.PGPFingerprint, &inv.Status, &inv.CreatedAt, &inv.LastModified, &inv.Permissions)
+		var (
+			inv  mig.Investigator
+			perm int64
+		)
+		err = rows.Scan(&inv.ID, &inv.Name, &inv.PGPFingerprint, &inv.Status, &inv.CreatedAt, &inv.LastModified, &perm)
 		if err != nil {
 			err = fmt.Errorf("Failed to retrieve investigator data: '%v'", err)
 			return
 		}
+		inv.Permissions.FromMask(perm)
 		investigators = append(investigators, inv)
 	}
 	if err := rows.Err(); err != nil {

--- a/database/searches.go
+++ b/database/searches.go
@@ -699,7 +699,8 @@ func (db *DB) SearchInvestigators(p search.Parameters) (investigators []mig.Inve
 		return
 	}
 	columns := `investigators.id, investigators.name, investigators.pgpfingerprint,
-		investigators.status, investigators.createdat, investigators.lastmodified`
+		investigators.status, investigators.createdat, investigators.lastmodified,
+		investigators.permissions`
 	join := ""
 	where := ""
 	vals := []interface{}{}
@@ -847,7 +848,7 @@ func (db *DB) SearchInvestigators(p search.Parameters) (investigators []mig.Inve
 	}
 	for rows.Next() {
 		var inv mig.Investigator
-		err = rows.Scan(&inv.ID, &inv.Name, &inv.PGPFingerprint, &inv.Status, &inv.CreatedAt, &inv.LastModified)
+		err = rows.Scan(&inv.ID, &inv.Name, &inv.PGPFingerprint, &inv.Status, &inv.CreatedAt, &inv.LastModified, &inv.Permissions)
 		if err != nil {
 			err = fmt.Errorf("Failed to retrieve investigator data: '%v'", err)
 			return

--- a/doc/console.rst
+++ b/doc/console.rst
@@ -443,54 +443,74 @@ Creating investigators
 
 To create a new investigator, go back to **mig>** mode and type
 **create investigator**. The console will prompt the name of the new
-investigator as well as the location of her public PGP key. You can either
-provide a local path to the public key file on disk, on provide a fingerprint
-in the format "0x<40 char sha1 hash>". When a fingerprint is provided, the
-console will attempt to retrieve the key from the keyserver `gpg.mozilla.org`::
+investigator, if additional permissions should be set, and as well 
+the location of her public PGP key.
 
-	mig> create investigator
-	Entering investigator creation mode. Please provide the full name
-	and the public key of the new investigator.
-	name> Bob Kelso
-	Name: 'Bob Kelso'
-	Please provide a public key. You can either provide a local path to the
-	armored public key file, or a full length PGP fingerprint.
-	example:
-	pubkey> 0x716CFA6BA8EBB21E860AE231645090E64367737B
-	pubkey> 0x716CFA6BA8EBB21E860AE231645090E64367737B
-	retrieving public key from http://gpg.mozilla.org
-	-----BEGIN PGP PUBLIC KEY BLOCK-----
-	Version: SKS 1.1.5
-	Comment: Hostname: keyserver.mozilla.org
+By default unless specific investigators will be created with no
+additional permissions. Answering yes to the permission related
+questions grant the investigator additional access to API functionality.
 
-	mQENBEbv+5sBCADNHPvUIajRoxb/qylLrzwm9e+9sB8R/jhY4gxOzGZRDHECPvNeTUd9eogV
-	n24rQDTWowkE+t9sW7vlD3TUWdBEAhXEpDZBfzlTBWIzEb1m3hwPOQM10ZNX6jPS1WlGsfoE
-	LsUC0HmFTtOx4b5os9mIYbsjsDWd/JZjn0yUIv4eb28+fle6BkbgqIotLW4d1gTrxVlFc3be
-	m+4OqimQ/v2LZDV+uObEkbh4UvmTtOCCx8zAOyZohPmICUbmJBc8KWWhzLOo8b9ns/GqP41q
-	/9IuTQDXP2GUAKXzBKSdQiNzJP8Skfu4tPyGsGJSErprPC9t43HPPUgfeW9/sfuaw+vnABEB
-	AAG0JUp1bGllbiBWRUhFTlQgPGp1bGllbkBsaW51eHdhbGwuaW5mbz6JATYEEwECACAFAkbv
-	+5sCGy8GCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAKCRBkUJDmQ2dze5U9CADK4Z6X02TP9afJ
-	AyWF32zM3UdMksJ/F2wuo2HBHT0iOomw4ecNzHyO1P5BTglm5LC5ZZrV+Dx6Jve75JiSDTSD
-	V3AhpR+M83rw8YKkeUrbTvfsy3+qhB7HYNIbCKT0lgAAL05SmDnYwYMQIV+p3T0F8BgGhkGT
-	vHdKLhzEhKNOMaMCwCd1SsiBepA976oBUp9h5Vt6TEFyG6hCcFP90DFjNlK17yMNjbdrgyd6
-	FkGEePKK3RhaLxcPShAgCnYzYYMABLYu1ow5AxxtEJTBHkJFkIzE9XM/lmyekYhWfX/Q4jpn
-	1aiiVlf2klZlFSFy/TXuuQH1JO3YlKo9uHjlvSQb
-	=+Ru1
-	-----END PGP PUBLIC KEY BLOCK-----
+You can either provide a local path to the public key file on disk,
+on provide a fingerprint in the format "0x<40 char sha1 hash>". When
+a fingerprint is provided, the console will attempt to retrieve the
+key from the keyserver `gpg.mozilla.org`::
 
-	create investigator? (y/n)> y
-	Investigator 'Bob Kelso' successfully created with ID 4
-
-	mig> investigator 4
-	Entering investigator mode. Type exit or press ctrl+d to leave. help may help.
-	Investigator 4 named 'Bob Kelso'
-
-	inv 4> details
-	Investigator ID 4
-	name     Bob Kelso
-	status   active
-	key id   716CFA6BA8EBB21E860AE231645090E64367737B
-	created  2015-10-06 09:23:14.473307 -0400 EDT
-	modified 2015-10-06 09:23:14.473307 -0400 EDT
+        mig> create investigator
+        Entering investigator creation mode. Please provide the full name
+        and the public key of the new investigator.
+        name> Bob Kelso
+        Name: 'Bob Kelso'
+        With no additional permissions, the investigator will be permitted
+        access to run investigations. Answer yes to any of the following to add
+        additional permissions to the investigator.
+        
+        If this is the first investigator being added, you should make this
+        investigator an admin.
+        Allow investigator to manage users (admin)? (yes/no)> no
+        Investigator will not have administrative permissions
+        Allow investigator to manage loaders? (yes/no)> no
+        Investigator will not have loader management permissions
+        Allow investigator to manage manifests? (yes/no)> no
+        Investigator will not have manifest management permissions
+        Please provide a public key. You can either provide a local path to the
+        armored public key file, or a full length PGP fingerprint.
+        example:
+        pubkey> 0x716CFA6BA8EBB21E860AE231645090E64367737B
+        pubkey> 0x716CFA6BA8EBB21E860AE231645090E64367737B
+        retrieving public key from http://gpg.mozilla.org
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.1.5
+        Comment: Hostname: keyserver.mozilla.org
+        
+        mQENBEbv+5sBCADNHPvUIajRoxb/qylLrzwm9e+9sB8R/jhY4gxOzGZRDHECPvNeTUd9eogV
+        n24rQDTWowkE+t9sW7vlD3TUWdBEAhXEpDZBfzlTBWIzEb1m3hwPOQM10ZNX6jPS1WlGsfoE
+        LsUC0HmFTtOx4b5os9mIYbsjsDWd/JZjn0yUIv4eb28+fle6BkbgqIotLW4d1gTrxVlFc3be
+        m+4OqimQ/v2LZDV+uObEkbh4UvmTtOCCx8zAOyZohPmICUbmJBc8KWWhzLOo8b9ns/GqP41q
+        /9IuTQDXP2GUAKXzBKSdQiNzJP8Skfu4tPyGsGJSErprPC9t43HPPUgfeW9/sfuaw+vnABEB
+        AAG0JUp1bGllbiBWRUhFTlQgPGp1bGllbkBsaW51eHdhbGwuaW5mbz6JATYEEwECACAFAkbv
+        +5sCGy8GCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAKCRBkUJDmQ2dze5U9CADK4Z6X02TP9afJ
+        AyWF32zM3UdMksJ/F2wuo2HBHT0iOomw4ecNzHyO1P5BTglm5LC5ZZrV+Dx6Jve75JiSDTSD
+        V3AhpR+M83rw8YKkeUrbTvfsy3+qhB7HYNIbCKT0lgAAL05SmDnYwYMQIV+p3T0F8BgGhkGT
+        vHdKLhzEhKNOMaMCwCd1SsiBepA976oBUp9h5Vt6TEFyG6hCcFP90DFjNlK17yMNjbdrgyd6
+        FkGEePKK3RhaLxcPShAgCnYzYYMABLYu1ow5AxxtEJTBHkJFkIzE9XM/lmyekYhWfX/Q4jpn
+        1aiiVlf2klZlFSFy/TXuuQH1JO3YlKo9uHjlvSQb
+        =+Ru1
+        -----END PGP PUBLIC KEY BLOCK-----
+        
+        create investigator? (y/n)> y
+        Investigator 'Bob Kelso' successfully created with ID 4
+        
+        mig> investigator 4
+        Entering investigator mode. Type exit or press ctrl+d to leave. help may help.
+        Investigator 4 named 'Bob Kelso'
+        
+        inv 4> details
+        Investigator ID 4
+        name        Bob Kelso
+        status      active
+        permissions 0 (Investigator only)
+        key id      716CFA6BA8EBB21E860AE231645090E64367737B
+        created     2015-10-06 09:23:14.473307 -0400 EDT
+        modified    2015-10-06 09:23:14.473307 -0400 EDT
 
 The new investigator now has access to the API.

--- a/doc/loader.rst
+++ b/doc/loader.rst
@@ -231,9 +231,10 @@ Next we need to send our new manifest to the API, so it is available to be
 fetched by loader instances we are running. This is accomplished using
 mig-console.
 
-A MIG administrator account is required for this. To make an account an
-administrator account, the ``isadmin`` column for the investigator in the
-``investigators`` table should be set to ``true``.
+Permission to manage manifests must be set on your investigator to create
+manifests. Ensure the PermManifests permission has been applied; you can
+validate this by looking at the details for your investigator in ``mig-console``,
+and can use the ``setperms`` command if needed.
 
 The ``create manifest`` command is used to create the new manifest.
 
@@ -307,6 +308,11 @@ sending a loader key to the API, which should be unique per endpoint loader inst
 The loader key is essentially an API token. In this example, we will create a new
 loader instance for a Linux system, so we can deploy the manifest we just created
 to that system.
+
+Permission to manage loaders must be set on your investigator to create
+loaders. Ensure the PermLoaders permission has been applied; you can
+validate this by looking at the details for your investigator in ``mig-console``,
+and can use the ``setperms`` command if needed.
 
 ::
 

--- a/investigator.go
+++ b/investigator.go
@@ -7,6 +7,8 @@
 package mig /* import "mig.ninja/mig" */
 
 import (
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -19,10 +21,62 @@ type Investigator struct {
 	Status         string    `json:"status"`
 	CreatedAt      time.Time `json:"createdat"`
 	LastModified   time.Time `json:"lastmodified"`
-	IsAdmin        bool      `json:"isadmin"`
+	Permissions    int       `json:"permissions"`
 }
 
 const (
 	StatusActiveInvestigator   string = "active"
 	StatusDisabledInvestigator string = "disabled"
 )
+
+// Permissions that can be assigned to investigators
+const (
+	PermLoaders   = 1 << iota // Create and manage loaders
+	PermManifests             // Create and manage manifests
+	PermAdmin                 // Create and manage investigators
+)
+
+type InvestigatorPermText struct {
+	Text  string
+	Value int
+}
+
+// InvestigatorPermissions maps permission string values to the actual
+// permission values that can be set in the bitmask; used primarily for
+// display purposes within UI
+//
+// By default, an investigator has no additional permissions which means
+// the investigator can run investigations, review action results, etc.
+// If additional permissions are applied, this gives the investigator
+// access to additional endpoints related to administration of the MIG
+// platform.
+var InvestigatorPermissions = []InvestigatorPermText{
+	{Text: "PermLoaders", Value: PermLoaders},
+	{Text: "PermManifests", Value: PermManifests},
+	{Text: "PermAdmin", Value: PermAdmin},
+}
+
+// Return a value representing all possible permissions an investigator
+// can have
+func InvestigatorPermsAll() int {
+	return PermLoaders | PermManifests | PermAdmin
+}
+
+// Process a list of permission string values and return a permission
+// bitmask
+func InvestigatorPermsFromStrings(slist []string) (int, error) {
+	ret := 0
+	for _, x := range slist {
+		found := false
+		for _, y := range InvestigatorPermissions {
+			if strings.ToLower(y.Text) == strings.ToLower(x) {
+				ret |= y.Value
+				found = true
+			}
+		}
+		if !found {
+			return 0, fmt.Errorf("Invalid permission %v", x)
+		}
+	}
+	return ret, nil
+}

--- a/investigator.go
+++ b/investigator.go
@@ -8,7 +8,6 @@ package mig /* import "mig.ninja/mig" */
 
 import (
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -21,62 +20,317 @@ type Investigator struct {
 	Status         string    `json:"status"`
 	CreatedAt      time.Time `json:"createdat"`
 	LastModified   time.Time `json:"lastmodified"`
-	Permissions    int       `json:"permissions"`
+
+	Permissions InvestigatorPerms `json:"permissions"`
 }
+
+// Check an investigator has given permission pv
+func (i *Investigator) CheckPermission(pv int64) bool {
+	switch pv {
+	case PermSearch:
+		return i.Permissions.Search
+	case PermAction:
+		return i.Permissions.Action
+	case PermActionCreate:
+		return i.Permissions.ActionCreate
+	case PermCommand:
+		return i.Permissions.Command
+	case PermAgent:
+		return i.Permissions.Agent
+	case PermDashboard:
+		return i.Permissions.Dashboard
+	case PermLoader:
+		return i.Permissions.Loader
+	case PermLoaderStatus:
+		return i.Permissions.LoaderStatus
+	case PermLoaderExpect:
+		return i.Permissions.LoaderExpect
+	case PermLoaderKey:
+		return i.Permissions.LoaderKey
+	case PermLoaderNew:
+		return i.Permissions.LoaderNew
+	case PermManifest:
+		return i.Permissions.Manifest
+	case PermManifestSign:
+		return i.Permissions.ManifestSign
+	case PermManifestNew:
+		return i.Permissions.ManifestNew
+	case PermManifestLoaders:
+		return i.Permissions.ManifestLoaders
+	case PermInvestigator:
+		return i.Permissions.Investigator
+	case PermInvestigatorCreate:
+		return i.Permissions.InvestigatorCreate
+	case PermInvestigatorUpdate:
+		return i.Permissions.InvestigatorUpdate
+	}
+	return false
+}
+
+// Describes permissions assigned to an investigator
+type InvestigatorPerms struct {
+	Search             bool `json:"search"`
+	Action             bool `json:"action"`
+	ActionCreate       bool `json:"action_create"`
+	Command            bool `json:"command"`
+	Agent              bool `json:"agent"`
+	Dashboard          bool `json:"dashboard"`
+	Loader             bool `json:"loader"`
+	LoaderStatus       bool `json:"loader_status"`
+	LoaderExpect       bool `json:"loader_expect"`
+	LoaderKey          bool `json:"loader_key"`
+	LoaderNew          bool `json:"loader_new"`
+	Manifest           bool `json:"manifest"`
+	ManifestSign       bool `json:"manifest_sign"`
+	ManifestStatus     bool `json:"manifest_status"`
+	ManifestNew        bool `json:"manifest_new"`
+	ManifestLoaders    bool `json:"manifest_loaders"`
+	Investigator       bool `json:"investigator"`
+	InvestigatorCreate bool `json:"investigator_create"`
+	InvestigatorUpdate bool `json:"investigator_update"`
+}
+
+// Convert a permission bit mask into a boolean permission set
+func (ip *InvestigatorPerms) FromMask(mask int64) {
+	if (mask & PermSearch) != 0 {
+		ip.Search = true
+	}
+	if (mask & PermAction) != 0 {
+		ip.Action = true
+	}
+	if (mask & PermActionCreate) != 0 {
+		ip.ActionCreate = true
+	}
+	if (mask & PermCommand) != 0 {
+		ip.Command = true
+	}
+	if (mask & PermAgent) != 0 {
+		ip.Agent = true
+	}
+	if (mask & PermDashboard) != 0 {
+		ip.Dashboard = true
+	}
+	if (mask & PermLoader) != 0 {
+		ip.Loader = true
+	}
+	if (mask & PermLoaderStatus) != 0 {
+		ip.LoaderStatus = true
+	}
+	if (mask & PermLoaderExpect) != 0 {
+		ip.LoaderExpect = true
+	}
+	if (mask & PermLoaderKey) != 0 {
+		ip.LoaderKey = true
+	}
+	if (mask & PermLoaderNew) != 0 {
+		ip.LoaderNew = true
+	}
+	if (mask & PermManifest) != 0 {
+		ip.Manifest = true
+	}
+	if (mask & PermManifestSign) != 0 {
+		ip.ManifestSign = true
+	}
+	if (mask & PermManifestNew) != 0 {
+		ip.ManifestNew = true
+	}
+	if (mask & PermManifestStatus) != 0 {
+		ip.ManifestStatus = true
+	}
+	if (mask & PermManifestLoaders) != 0 {
+		ip.ManifestLoaders = true
+	}
+	if (mask & PermInvestigator) != 0 {
+		ip.Investigator = true
+	}
+	if (mask & PermInvestigatorCreate) != 0 {
+		ip.InvestigatorCreate = true
+	}
+	if (mask & PermInvestigatorUpdate) != 0 {
+		ip.InvestigatorUpdate = true
+	}
+}
+
+// Convert a boolean permission set to a permission bit mask
+func (ip *InvestigatorPerms) ToMask() (ret int64) {
+	if ip.Search {
+		ret |= PermSearch
+	}
+	if ip.Action {
+		ret |= PermAction
+	}
+	if ip.ActionCreate {
+		ret |= PermActionCreate
+	}
+	if ip.Command {
+		ret |= PermCommand
+	}
+	if ip.Agent {
+		ret |= PermAgent
+	}
+	if ip.Dashboard {
+		ret |= PermDashboard
+	}
+	if ip.Loader {
+		ret |= PermLoader
+	}
+	if ip.LoaderStatus {
+		ret |= PermLoaderStatus
+	}
+	if ip.LoaderExpect {
+		ret |= PermLoaderExpect
+	}
+	if ip.LoaderKey {
+		ret |= PermLoaderKey
+	}
+	if ip.LoaderNew {
+		ret |= PermLoaderNew
+	}
+	if ip.Manifest {
+		ret |= PermManifest
+	}
+	if ip.ManifestSign {
+		ret |= PermManifestSign
+	}
+	if ip.ManifestNew {
+		ret |= PermManifestNew
+	}
+	if ip.ManifestStatus {
+		ret |= PermManifestStatus
+	}
+	if ip.ManifestLoaders {
+		ret |= PermManifestLoaders
+	}
+	if ip.Investigator {
+		ret |= PermInvestigator
+	}
+	if ip.InvestigatorCreate {
+		ret |= PermInvestigatorCreate
+	}
+	if ip.InvestigatorUpdate {
+		ret |= PermInvestigatorUpdate
+	}
+	return ret
+}
+
+// Convert an existing boolean permission set to a descriptive string
+func (ip *InvestigatorPerms) ToDescriptive() string {
+	ret := ""
+	tv := InvestigatorPerms{}
+	tv.DefaultSet()
+	if ip.ToMask()&tv.ToMask() != 0 {
+		ret = "Default"
+	}
+	tv = InvestigatorPerms{}
+	tv.ManifestSet()
+	if ip.ToMask()&tv.ToMask() != 0 {
+		if len(ret) > 0 {
+			ret += ","
+		}
+		ret += "PermManifest"
+	}
+	tv = InvestigatorPerms{}
+	tv.LoaderSet()
+	if ip.ToMask()&tv.ToMask() != 0 {
+		if len(ret) > 0 {
+			ret += ","
+		}
+		ret += "PermLoader"
+	}
+	tv = InvestigatorPerms{}
+	tv.AdminSet()
+	if ip.ToMask()&tv.ToMask() != 0 {
+		if len(ret) > 0 {
+			ret += ","
+		}
+		ret += "PermAdmin"
+	}
+	if ret == "" {
+		ret = "Unknown"
+	}
+	return ret
+}
+
+// Describe permission sets that can be applied; note default is omitted as this
+// is currently always applied
+var PermSets = []string{"PermManifest", "PermLoader", "PermAdmin"}
+
+// Apply permission sets in slice sl to the investigator
+func (ip *InvestigatorPerms) FromSetList(sl []string) error {
+	for _, x := range sl {
+		switch x {
+		case "PermManifest":
+			ip.ManifestSet()
+		case "PermLoader":
+			ip.LoaderSet()
+		case "PermAdmin":
+			ip.AdminSet()
+		default:
+			return fmt.Errorf("invalid permission %q", x)
+		}
+	}
+	return nil
+}
+
+// Set a default set of permissions on the investigator
+func (ip *InvestigatorPerms) DefaultSet() {
+	ip.Search = true
+	ip.Action = true
+	ip.ActionCreate = true
+	ip.Command = true
+	ip.Agent = true
+	ip.Dashboard = true
+}
+
+// Set manifest related permissions on the investigator
+func (ip *InvestigatorPerms) ManifestSet() {
+	ip.Manifest = true
+	ip.ManifestSign = true
+	ip.ManifestNew = true
+	ip.ManifestStatus = true
+	ip.ManifestLoaders = true
+}
+
+// Set loader related permissions on the investigator
+func (ip *InvestigatorPerms) LoaderSet() {
+	ip.Loader = true
+	ip.LoaderStatus = true
+	ip.LoaderExpect = true
+	ip.LoaderKey = true
+	ip.LoaderNew = true
+}
+
+// Set administrative permissions on the investigator
+func (ip *InvestigatorPerms) AdminSet() {
+	ip.Investigator = true
+	ip.InvestigatorCreate = true
+	ip.InvestigatorUpdate = true
+}
+
+// Permissions that can be assigned to investigators
+const (
+	PermSearch = 1 << iota
+	PermAction
+	PermActionCreate
+	PermCommand
+	PermAgent
+	PermDashboard
+	PermLoader
+	PermLoaderStatus
+	PermLoaderExpect
+	PermLoaderKey
+	PermLoaderNew
+	PermManifest
+	PermManifestSign
+	PermManifestNew
+	PermManifestStatus
+	PermManifestLoaders
+	PermInvestigator
+	PermInvestigatorCreate
+	PermInvestigatorUpdate
+)
 
 const (
 	StatusActiveInvestigator   string = "active"
 	StatusDisabledInvestigator string = "disabled"
 )
-
-// Permissions that can be assigned to investigators
-const (
-	PermLoaders   = 1 << iota // Create and manage loaders
-	PermManifests             // Create and manage manifests
-	PermAdmin                 // Create and manage investigators
-)
-
-type InvestigatorPermText struct {
-	Text  string
-	Value int
-}
-
-// InvestigatorPermissions maps permission string values to the actual
-// permission values that can be set in the bitmask; used primarily for
-// display purposes within UI
-//
-// By default, an investigator has no additional permissions which means
-// the investigator can run investigations, review action results, etc.
-// If additional permissions are applied, this gives the investigator
-// access to additional endpoints related to administration of the MIG
-// platform.
-var InvestigatorPermissions = []InvestigatorPermText{
-	{Text: "PermLoaders", Value: PermLoaders},
-	{Text: "PermManifests", Value: PermManifests},
-	{Text: "PermAdmin", Value: PermAdmin},
-}
-
-// Return a value representing all possible permissions an investigator
-// can have
-func InvestigatorPermsAll() int {
-	return PermLoaders | PermManifests | PermAdmin
-}
-
-// Process a list of permission string values and return a permission
-// bitmask
-func InvestigatorPermsFromStrings(slist []string) (int, error) {
-	ret := 0
-	for _, x := range slist {
-		found := false
-		for _, y := range InvestigatorPermissions {
-			if strings.ToLower(y.Text) == strings.ToLower(x) {
-				ret |= y.Value
-				found = true
-			}
-		}
-		if !found {
-			return 0, fmt.Errorf("Invalid permission %v", x)
-		}
-	}
-	return ret, nil
-}

--- a/mig-api/investigator_endpoints.go
+++ b/mig-api/investigator_endpoints.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -95,11 +96,9 @@ func createInvestigator(respWriter http.ResponseWriter, request *http.Request) {
 	if inv.Name == "" {
 		panic("Investigator name must not be empty")
 	}
-	tmpperm := request.FormValue("permissions")
-	if tmpperm == "" {
-		panic("Investigator permissions must not be empty")
-	}
-	inv.Permissions, err = strconv.Atoi(tmpperm)
+	// Parse incoming permissions as JSON InvestigatorPerms
+	permbuf := request.FormValue("permissions")
+	err = json.Unmarshal([]byte(permbuf), &inv.Permissions)
 	if err != nil {
 		panic(err)
 	}
@@ -180,7 +179,7 @@ func updateInvestigator(respWriter http.ResponseWriter, request *http.Request) {
 		}
 		ctx.Channels.Log <- mig.Log{OpID: opid, Desc: fmt.Sprintf("Investigator %.0f status changed to %s", inv.ID, inv.Status)}
 	} else {
-		inv.Permissions, err = strconv.Atoi(invperm)
+		err = json.Unmarshal([]byte(invperm), &inv.Permissions)
 		if err != nil {
 			panic(err)
 		}
@@ -188,7 +187,7 @@ func updateInvestigator(respWriter http.ResponseWriter, request *http.Request) {
 		if err != nil {
 			panic(err)
 		}
-		ctx.Channels.Log <- mig.Log{OpID: opid, Desc: fmt.Sprintf("Investigator %.0f permissions changed to %v", inv.ID, inv.Permissions)}
+		ctx.Channels.Log <- mig.Log{OpID: opid, Desc: fmt.Sprintf("Investigator %.0f permissions changed", inv.ID)}
 	}
 	err = resource.AddItem(cljs.Item{
 		Href: fmt.Sprintf("%s/investigator?investigatorid=%.0f", ctx.Server.BaseURL, inv.ID),

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -275,7 +275,7 @@ gpg --no-default-keyring --keyring ~/.mig/pubring.gpg \
     --secret-keyring ~/.mig/secring.gpg \
     --export -a $(whoami)@$(hostname) \
     > ~/.mig/$(whoami)-pubkey.asc || fail
-echo -e "create investigator\n$(whoami)\nyes\n$HOME/.mig/$(whoami)-pubkey.asc\ny\n" | \
+echo -e "create investigator\n$(whoami)\nyes\nyes\nyes\n$HOME/.mig/$(whoami)-pubkey.asc\ny\n" | \
     /usr/local/bin/mig-console -q || fail
 
 echo -e "\n---- Creating agent configuration\n"


### PR DESCRIPTION
This removes the previous implementation where an investigator could
either be set to an admin or not, and expands this to per-endpoint
permissions that can be set for individual investigators.