### PR TITLE
[minor] invert the logic to get the client hostname on Linux

### DIFF
--- a/mig-agent/agentcontext/env_linux.go
+++ b/mig-agent/agentcontext/env_linux.go
@@ -25,19 +25,16 @@ func findHostname(orig_ctx AgentContext) (ctx AgentContext, err error) {
 	}()
 
 	// get the hostname
-	out, err := exec.Command("hostname", "--fqdn").Output()
-	if err != nil {
-		// --fqdn can fail sometimes. when that happens, use Go's builtin
-		// hostname lookup (reads /proc/sys/kernel/hostname)
-		hostname, err := os.Hostname()
+	hostname, err := os.Hostname()
+	if (err != nil) || (hostname == "localhost") {
+		out, err := exec.Command("hostname", "--fqdn").Output()
 		if err != nil {
-			panic(err)
+			hostname = "localhost"
 		}
-		ctx.Hostname = hostname
-		return ctx, err
+		// remove trailing newline
+		hostname = fmt.Sprintf("%s", out[0:len(out)-1])
 	}
-	// remove trailing newline
-	ctx.Hostname = fmt.Sprintf("%s", out[0:len(out)-1])
+	ctx.Hostname = hostname
 	return
 }
 


### PR DESCRIPTION
First try to get the kernel hostname, if this fail or is localhost, try to get the filesystem hostname via
`hostname--fqdn` which basically lookups /etc/hosts /etc/hostname /etc/nsswitch.conf, etc.
Also, make this function never fail as having "localhost" as hostname is better than not starting at all (with
the previous logic it would still start with "localhost" anyway)