### PR TITLE
Implementation of agent EPM

### DIFF
--- a/conf/mig-agent-conf.go.inc
+++ b/conf/mig-agent-conf.go.inc
@@ -34,6 +34,11 @@ var DISCOVERAWSMETA = true
 // and exits. this mode is used to run the agent as a cron job, not a daemon.
 var CHECKIN = false
 
+// if enabled, the agent will inform modules to mask returned meta-data as much
+// as possible. modules which consider this will tell you they found something,
+// but not much else.
+var EXTRAPRIVACYMODE = false
+
 // how often the agent will refresh its environment. if 0 agent
 // will only update environment at initialization.
 var REFRESHENV time.Duration = 0

--- a/conf/mig-agent.cfg.inc
+++ b/conf/mig-agent.cfg.inc
@@ -43,6 +43,11 @@
     ; like "5m"
     refreshenv = ""
 
+    ; mask meta-data such as file names in search results from this agent. note that
+    ; honoring this flag is up to the module, and not all modules may consider
+    ; it. the default is off.
+    ; extraprivacymode = off
+
 [certs]
     ca  = "/path/to/ca/cert"
     cert= "/path/to/client/cert"

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -917,6 +917,28 @@ To obtain the PID of the running agent, use the following command:
 
 Leave the `SOCKET` configuration variable empty to disable the stat socket.
 
+Extra privacy mode (EPM)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+A design principle of MIG is that the agent protects privacy, and it will not
+return information such as file contents or memory contents in any configuration.
+It does however return meta-data that is useful to the investigator (such as
+file names).
+
+In some cases for example if you are running MIG on user workstations, you
+may want to deploy extra privacy controls. Extra privacy mode informs the agent
+that it should further mask certain result data. If enabled for example, the
+file module will report that it found something as the result of a search, but
+will not include file names.
+
+It is up to modules to honor the EPM setting; currently this value is used by
+the file module (mask filenames), the netstat module (mask addresses the system
+is communicating with), and the scribe module (mask test identifiers).
+
+EPM can be enabled in the agent configuration either via the `extraprivacymode`
+option in the configuration file, or setting `EXTRAPRIVACYMODE` to true in the
+built-in configuration.
+
 Logging
 ~~~~~~~
 

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -434,6 +434,21 @@ A typical implementation from the ``timedrift`` module looks as follows:
 It is highly recommended to call ``ValidateParameters`` to verify that the
 parameters supplied by the users are correct.
 
+HasEnhancedPrivacy
+~~~~~~~~~~~~~~~~~~
+
+Modules can implement the ``HasEnhancedPrivacy`` interface by providing an
+``EnhancePrivacy`` function.
+
+If extra privacy mode has been enabled in the agent configuration, results that
+are returned from a module will be passed through the modules ``EnhancePrivacy``
+function. This provides the module a means to mask certain meta-data as desired
+from the result set.
+
+The function is only run if extra privacy mode is enabled, if not the function
+will not be run on results. If the module does not implement ``HasEnhancedPrivacy``,
+the results are returned as-is.
+
 The Example module
 ==================
 

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -237,6 +237,28 @@ func runModuleDirectly(mode string, paramargs interface{}, pretty bool) (out str
 	// instantiate and call module
 	run := modules.Available[mode].NewRun()
 	out = run.Run(infd)
+
+	// if enhanced privacy mode has been requested, apply it to the result set
+	// if the module supports it
+	if EXTRAPRIVACYMODE {
+		if _, ok := run.(modules.HasEnhancedPrivacy); ok {
+			var restmp modules.Result
+			err := json.Unmarshal([]byte(out), &restmp)
+			if err != nil {
+				panic(err)
+			}
+			restmp, err = run.(modules.HasEnhancedPrivacy).EnhancePrivacy(restmp)
+			if err != nil {
+				panic(err)
+			}
+			resb, err := json.Marshal(restmp)
+			if err != nil {
+				panic(err)
+			}
+			out = string(resb)
+		}
+	}
+
 	if pretty {
 		var modres modules.Result
 		err := json.Unmarshal([]byte(out), &modres)

--- a/mig-agent/config.go
+++ b/mig-agent/config.go
@@ -31,6 +31,7 @@ type config struct {
 		ModuleTimeout    string
 		Api              string
 		RefreshEnv       string
+		ExtraPrivacyMode bool
 	}
 	Certs struct {
 		Ca, Cert, Key string
@@ -95,5 +96,6 @@ func configLoad(path string) (err error) {
 	AGENTCERT = agentcert
 	AGENTKEY = agentkey
 	REFRESHENV = refreshenv
+	EXTRAPRIVACYMODE = config.Agent.ExtraPrivacyMode
 	return
 }

--- a/modules/file/file.go
+++ b/modules/file/file.go
@@ -1820,3 +1820,23 @@ func (r *run) PrintResults(result modules.Result, foundOnly bool) (prints []stri
 	}
 	return
 }
+
+// Enhanced privacy mode for file module, mask file names being returned by the module
+func (r *run) EnhancePrivacy(in modules.Result) (out modules.Result, err error) {
+	var el SearchResults
+	out = in
+	err = out.GetElements(&el)
+	if err != nil {
+		return
+	}
+	for k, v := range el {
+		for i := range v {
+			if v[i].File != "" {
+				v[i].File = "masked"
+			}
+		}
+		el[k] = v
+	}
+	out.Elements = el
+	return
+}

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -225,6 +225,10 @@ func (r Result) GetStatistics(stats interface{}) (err error) {
 	return
 }
 
+type HasEnhancedPrivacy interface {
+	EnhancePrivacy(Result) (Result, error)
+}
+
 // HasParamsCreator implements a function that creates module parameters
 type HasParamsCreator interface {
 	ParamsCreator() (interface{}, error)

--- a/modules/netstat/netstat.go
+++ b/modules/netstat/netstat.go
@@ -467,3 +467,25 @@ func (r *run) PrintResults(result modules.Result, matchOnly bool) (prints []stri
 	prints = append(prints, resStr)
 	return
 }
+
+// Enhanced privacy mode for the netstat module, mask returned address information
+//
+// On an agent with enhanced privacy mode enabled, this does not provide much for queries
+// directed to a small address group, but can prevent returning results from a large
+// query scope (e.g., all connected ip's matching 0.0.0.0/0); we only apply it to information
+// returned in the ConnectedIP element.
+func (r *run) EnhancePrivacy(in modules.Result) (out modules.Result, err error) {
+	var el elements
+	out = in
+	err = out.GetElements(&el)
+	if err != nil {
+		return
+	}
+	for k, v := range el.ConnectedIP {
+		for i := range v {
+			el.ConnectedIP[k][i].RemoteAddr = "masked"
+		}
+	}
+	out.Elements = el
+	return
+}

--- a/modules/scribe/scribe.go
+++ b/modules/scribe/scribe.go
@@ -246,3 +246,21 @@ type parameters struct {
 func newParameters() *parameters {
 	return &parameters{}
 }
+
+// Enhanced privacy mode for scribe module, mask identifiers
+func (r *run) EnhancePrivacy(in modules.Result) (out modules.Result, err error) {
+	var el ScribeElements
+
+	out = in
+	err = out.GetElements(&el)
+	if err != nil {
+		return
+	}
+	for i := range el.Results {
+		for j := range el.Results[i].Results {
+			el.Results[i].Results[j].Identifier = "masked"
+		}
+	}
+	out.Elements = el
+	return
+}

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -295,6 +295,7 @@ var MUSTINSTALLSERVICE bool = true
 var DISCOVERPUBLICIP bool = false
 var DISCOVERAWSMETA bool = true
 var CHECKIN bool = false
+var EXTRAPRIVACYMODE = false
 var APIURL string = "http://localhost:1664/api/v1/"
 var LOGGINGCONF = mig.Logging{
     Mode:   "file",


### PR DESCRIPTION
Adds an extra privacy mode configuration option to the agent which provides data masking beyond the privacy protections that already exist in MIG. With this option enabled, modules which honor the flag will mask certain meta-data in the responses.

Implemented for the file module, netstat module, and scribe module.