### PR TITLE
[Minor]Clients should provide method to disable color terminal escape…

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -46,10 +46,11 @@ type Client struct {
 
 // Configuration stores the live configuration and global parameters of a client
 type Configuration struct {
-	API     ApiConf    // location of the MIG API
-	Homedir string     // location of the user's home directory
-	GPG     GpgConf    // location of the user's secring
-	Targets TargetConf // Target macro specification
+	API      ApiConf      // location of the MIG API
+	Homedir  string       // location of the user's home directory
+	GPG      GpgConf      // location of the user's secring
+	Targets  TargetConf   // Target macro specification
+	Terminal TerminalConf // Terminal configuration
 }
 
 type ApiConf struct {
@@ -65,6 +66,28 @@ type GpgConf struct {
 type TargetConf struct {
 	Macro  []string
 	macros map[string]string
+}
+
+type TerminalConf struct {
+	Color bool
+}
+
+//Used for color print in terminal base on color flag
+//in configuration file
+func (clr TerminalConf) Printf(c string, s string, a ...interface{}) {
+	if clr.Color {
+		fmt.Printf("\x1b["+c+"m"+s+"\x1b[0m", a...)
+	} else {
+		fmt.Printf(s, a...)
+	}
+}
+
+func (clr TerminalConf) Fprintf(w io.Writer, c string, s string, a ...interface{}) {
+	if clr.Color {
+		fmt.Fprintf(w, "\x1b["+c+"m"+s+"\x1b[0m", a...)
+	} else {
+		fmt.Fprintf(w, s, a...)
+	}
 }
 
 // Used by the macro parser to add processed target macros to the client
@@ -266,6 +289,7 @@ func MakeConfiguration(file string) (err error) {
 	}
 	fmt.Fprintf(fd, "[api]\n\turl = \"%s\"\n", cfg.API.URL)
 	fmt.Fprintf(fd, "[gpg]\n\thome = \"%s\"\n\tkeyid = \"%s\"\n", cfg.GPG.Home, cfg.GPG.KeyID)
+	fmt.Fprintf(fd, "[TerminalConf]\n\tcolor = off\n")
 	fd.Close()
 	fmt.Println("MIG client configuration generated at", file)
 	return

--- a/client/mig-console/console.go
+++ b/client/mig-console/console.go
@@ -53,19 +53,6 @@ func main() {
 	}
 	defer out.Close()
 
-	fmt.Fprintf(out, "\x1b[32;1m"+banner+"\x1b[0m")
-
-	// append a space after completion
-	readline.CompletionAppendChar = 0x20
-	// load history
-	historyfile := homedir + "/.mig_history"
-	fi, err := os.Stat(historyfile)
-	if err == nil && fi.Size() > 0 {
-		err = readline.LoadHistory(historyfile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to load history from %s\n", historyfile)
-		}
-	}
 	// instanciate an API client
 	conf, err := client.ReadConfiguration(*config)
 	if err != nil {
@@ -78,6 +65,22 @@ func main() {
 	if *verbose {
 		cli.EnableDebug()
 	}
+
+	Terminal := cli.Conf.Terminal
+
+	Terminal.Fprintf(out, "32;1", banner)
+	// append a space after completion
+	readline.CompletionAppendChar = 0x20
+	// load history
+	historyfile := homedir + "/.mig_history"
+	fi, err := os.Stat(historyfile)
+	if err == nil && fi.Size() > 0 {
+		err = readline.LoadHistory(historyfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to load history from %s\n", historyfile)
+		}
+	}
+
 	// print platform status
 	err = printStatus(cli)
 	if err != nil {

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -268,6 +268,8 @@ cat > ~/.migrc << EOF
 [gpg]
     home = "$HOME/.mig/"
     keyid = "$keyid"
+[Terminal]
+    color = off
 EOF
 
 echo -e "\n---- Creating investigator $(whoami) in database\n"


### PR DESCRIPTION
I am providing a fix to this bug for review after that i will complete this whole task. 
I added a new struct Terminal in configuration and write method of that which is able to enable/disable color according to flag set in .migrc.
So if in future for writing colorful in terminal we will use the method of struct Terminal instead of direct fmt.Printf etc. 
There is also a argument which decide the color of text.  
