### PR TITLE
[minor] support passphrase input via env

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -180,6 +180,23 @@ func ReadConfiguration(file string) (conf Configuration, err error) {
 	return
 }
 
+// Read any possible configuration values from the environment; currently we only
+// load a passphrase here if provided, but conf is passed/returned for any future
+// requirements to override file based configuration using environment options.
+func ReadEnvConfiguration(inconf Configuration) (conf Configuration, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("ReadEnvConfiguration() -> %v", e)
+		}
+	}()
+	conf = inconf
+	pf := os.Getenv("MIGPGPPASSPHRASE")
+	if pf != "" {
+		ClientPassphrase(pf)
+	}
+	return
+}
+
 func FindHomedir() string {
 	if os.Getenv("HOME") != "" {
 		return os.Getenv("HOME")

--- a/client/mig-agent-search/main.go
+++ b/client/mig-agent-search/main.go
@@ -145,6 +145,10 @@ Command line flags:
 	if err != nil {
 		panic(err)
 	}
+	conf, err = client.ReadEnvConfiguration(conf)
+	if err != nil {
+		panic(err)
+	}
 	cli, err := client.NewClient(conf, "agent-search-"+mig.Version)
 	if err != nil {
 		panic(err)

--- a/client/mig-console/console.go
+++ b/client/mig-console/console.go
@@ -71,6 +71,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	conf, err = client.ReadEnvConfiguration(conf)
+	if err != nil {
+		panic(err)
+	}
 	cli, err := client.NewClient(conf, "console-"+mig.Version)
 	if err != nil {
 		panic(err)

--- a/client/mig/main.go
+++ b/client/mig/main.go
@@ -134,6 +134,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	conf, err = client.ReadEnvConfiguration(conf)
+	if err != nil {
+		panic(err)
+	}
 	cli, err = client.NewClient(conf, "cmd-"+mig.Version)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Not intended for use in the general case, but permits using various mig
command line tools in an automated manner more easily.