### PR TITLE
[medium/bug] Prevent one investigator from signing multiple times

### DIFF
--- a/action.go
+++ b/action.go
@@ -365,14 +365,6 @@ func (a Action) VerifyACL(acl ACL, keyring io.Reader) (err error) {
 		if err != nil {
 			return fmt.Errorf("Failed to retrieve fingerprint from signatures: %v", err)
 		}
-		// Make sure this key fingerprint is not already present; the API prevents
-		// submission of signatures from the same fingerprint but this is a second
-		// check.
-		for _, cfp := range fingerprints {
-			if cfp == fp {
-				return fmt.Errorf("Duplicate fingerprint: %v", fp)
-			}
-		}
 		fingerprints = append(fingerprints, fp)
 	}
 


### PR DESCRIPTION
This patch fixes a security issue in the ACL verification code
that allows a single investigator to sign an action multiple
times in order to meet the threshold required to run the action.

Given the lack of support for multiple signatures in the client
code until recently, and the fact the investigator still has to
be authorized to run the module anyway, this is considered MEDIUM.

r? @ameihm0912 