### PR TITLE
[minor] validate key format on osx loader installation

### DIFF
--- a/tools/osx-loader-pkg-postinstall.sh
+++ b/tools/osx-loader-pkg-postinstall.sh
@@ -10,23 +10,36 @@ chk() {
 }
 
 cnt=0
-while true; do
-	buf=$(osascript << EOF
-	display dialog "Please enter MIG registration token" default answer ""
-	set ret to text returned of result
-	return ret
-	EOF
-	)
-	if [ $? -eq 1 ]; then exit 1; fi
-	cnt=`expr $cnt + 1`
-	chk $buf
-	if [[ $? == "1" ]]; then
-		break
-	fi
-	if [[ $cnt -eq 3 ]]; then
-		exit 1
-	fi
-done
+buf=$(osascript << EOF
+set tries to 0
+repeat
+	set done to false
+	repeat 1 times
+		display dialog "Please enter MIG registration token" default answer ""
+		set ret to text returned of result
+		set keylen to length of ret
+		set valid to "0" = (do shell script ¬
+			"egrep -q '^\\\w{40}$' <<<" & quoted form of ret & "; printf \$?")
+		if not valid then
+			exit repeat
+		end if
+		set done to true
+	end repeat
+	if done then
+		exit repeat
+	end if
+	set tries to tries + 1
+	display alert "Invalid key format" as critical message "Your key should be 40 alphanumeric characters long, on a single line"
+	if tries is greater than 2 then
+		display alert "Giving up" as critical message "Verify your key is valid and try the installation again"
+		error "invalidkey"
+	end if
+end repeat
+return ret
+EOF
+)
+if [ $? -eq 1 ]; then exit 1; fi
+
 echo $buf > $loaderkeyfile
 
 # Run the loader once as part of startup


### PR DESCRIPTION
Validates key is correct format before using it on OSX.

Fixes #202