### PR TITLE
Persistent module support

### DIFF
--- a/conf/available_modules.go
+++ b/conf/available_modules.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	_ "mig.ninja/mig/modules/agentdestroy"
+	_ "mig.ninja/mig/modules/examplepersist"
 	_ "mig.ninja/mig/modules/file"
 	_ "mig.ninja/mig/modules/memory"
 	_ "mig.ninja/mig/modules/netstat"

--- a/conf/mig-agent-conf.go.inc
+++ b/conf/mig-agent-conf.go.inc
@@ -39,6 +39,10 @@ var CHECKIN = false
 // but not much else.
 var EXTRAPRIVACYMODE = false
 
+// spawn persistent modules; if enabled in the built-in config this can be
+// disabled at run-time using a config option or command line flag
+var SPAWNPERSISTENT = true
+
 // how often the agent will refresh its environment. if 0 agent
 // will only update environment at initialization.
 var REFRESHENV time.Duration = 0

--- a/conf/mig-agent.cfg.inc
+++ b/conf/mig-agent.cfg.inc
@@ -48,6 +48,9 @@
     ; it. the default is off.
     ; extraprivacymode = off
 
+    ; if true, persistent modules will not be executed by the agent
+    ; nopersistmods = off
+
 [certs]
     ca  = "/path/to/ca/cert"
     cert= "/path/to/client/cert"

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -20,6 +20,31 @@ base, and only imported during compilation of the agent. Go does not provide a
 way to load modules dynamically, so modules are compiled into the agent's static
 binary, and not as separate files.
 
+There are two types of modules. Standard modules, which were the initial module
+type supported by MIG, and persistent modules.
+
+A standard module is invoked by the agent when it recieves by a command, and the
+results provided by this module can be considered point in time. It does not keep
+any state between runs, and is used for general investigation activities. Some
+examples of standard modules include the ``file`` module for scanning the file
+system for certain criteria, or the ``netstat`` module for looking at current
+network communication.
+
+A persistent module is run by the agent when it starts, and can perform more
+on-going tasks or analysis activities. Persistent modules are kept running by
+the agent. Persistent modules can be queried just like standard modules, but
+instead of a one-time invocation of the module, when the investigator queries
+a persistent module you are querying into the already running module. This can
+be used to collect statistics or results, change the behavior of the persistent
+module, or various other activities.
+
+Persistent modules are developed in a similar manner to standard modules with a
+few additions. This discusses elements that are common to all modules. For details
+specific to the implementation of persistent modules see the `persistent module`_
+documentation.
+
+.. _`persistent module`: modulespersist.rst
+
 Module logic
 ============
 

--- a/doc/modulespersist.rst
+++ b/doc/modulespersist.rst
@@ -1,0 +1,92 @@
+======================
+Persistent MIG Modules
+======================
+
+.. sectnum::
+.. contents:: Table of Contents
+
+This document describes persistent modules and how they differ from standard
+MIG modules.
+
+Persistent modules are invoked when the agent starts, and run for the lifetime
+of the agent. They are supervised by the main agent process, and are restarted
+if a failure occurs or they are shut down. Persistent modules can be queried in
+the same way an investigator would query using a standard module, however instead
+of the module being invoked once for a point-in-time investigation, the persistent
+module is queried. This can be useful to return collected statistics on an on-going
+basis, or otherwise conduct investigations over a period of time. A persistent module
+can be considered to keep state over the course of its lifetime, where as a standard
+module returns results representing a given point in time.
+
+Persistent modules are required to implement all the same functions and satisfy
+the same interfaces as standard modules, but they also are required to implement
+a few additional components.
+
+For general information on modules, see the `module documentation`_. This builds off
+that documentation and is specific to the implementation of persistent modules.
+
+.. _`module documentation`: modules.rst
+
+Module logic
+============
+
+Registration
+------------
+
+All MIG modules must satisfy the Runner interface. Persistent modules must satisfy
+both the Runner interface, and the PersistRunner interface.
+
+.. code:: go
+
+	type PersistRunner interface {
+		RunPersist(io.ReadCloser, io.WriteCloser)
+	}
+
+Initial execution by the agent
+------------------------------
+
+When the agent starts up, any persistent modules will be started. This is done by
+spawning a supervisor goroutine which will start the modules by calling
+``mig-agent`` with the ``-P`` flag to indicate which persistent module to run.
+
+The main agent process starts the module up and supervisory related communication
+occurs over a pipe. Writes to and reads from the running persistent module process
+occur over a pipe. From the module side, Writes to and reads from the main agent
+process occur over stdout and stdin respectively.
+
+When the persistent module is started by the agent, the modules ``RunPersist()``
+function is executed. This function does not return, and is typically responsible
+for starting up any tasks the module wants to execute in goroutines. Following all
+this, the module will enter the ``modules.DefaultPersistHandlers()`` function which
+provides a consistent entry point to the handling of supervisor messages between the
+agent and the running module.
+
+Querying persistent modules
+---------------------------
+
+When the agent receives a request to query a persistent module, the general flow
+can be described as follows.
+
+::
+
+	Agent			module -m			module -P
+	+---+			+-------+			+-------+
+	Parameters ------stdin->|					|
+				| Run() -------------listener---------->|----->+
+				|					|      | Persist request handler
+				|					|      |
+	<---------------stdout--|<-------------------listener-----------|<-----+
+
+* The agent calls itself with the ``-m`` flag, and sends the parameters into stdin of the new process.
+* The modules Run() method is called; this connects to the socket the persistent module is listening on, and submits the same parameter set.
+* The running persistent module accepts the new connection, parses the parameters and returns a result.
+* The ``-m`` query process reads the result from the socket, and returns it to the agent on stdout.
+
+Each new request entering the persistent module is handled in a new go-routine in the
+running module. Care must be taken inside this module that data structures are locked or protected
+as concurrent operations can occur with multiple queries hitting the module at the same time.
+
+Additional details
+==================
+
+For additional details and examples, the examplepersist module should be reviewed.

--- a/mig-agent/config.go
+++ b/mig-agent/config.go
@@ -31,6 +31,7 @@ type config struct {
 		ModuleTimeout    string
 		Api              string
 		RefreshEnv       string
+		NoPersistMods    bool
 		ExtraPrivacyMode bool
 	}
 	Certs struct {
@@ -97,5 +98,8 @@ func configLoad(path string) (err error) {
 	AGENTKEY = agentkey
 	REFRESHENV = refreshenv
 	EXTRAPRIVACYMODE = config.Agent.ExtraPrivacyMode
+	if config.Agent.NoPersistMods {
+		SPAWNPERSISTENT = false
+	}
 	return
 }

--- a/mig-agent/persist.go
+++ b/mig-agent/persist.go
@@ -1,0 +1,181 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor:
+// - Aaron Meihm ameihm@mozilla.com [:alm]
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"mig.ninja/mig"
+	"mig.ninja/mig/modules"
+)
+
+func startPersist(ctx *Context) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("startPersist() -> %v", e)
+		}
+	}()
+	ctx.Channels.Log <- mig.Log{Desc: "initializing any persistent modules"}.Debug()
+
+	for k, v := range modules.Available {
+		if _, ok := v.NewRun().(modules.PersistRunner); ok {
+			err = startPersistModule(ctx, k)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+	return
+}
+
+func startPersistModule(ctx *Context, name string) (err error) {
+	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("starting persistent module %v", name)}.Info()
+	go managePersistModule(ctx, name)
+	return
+}
+
+func managePersistModule(ctx *Context, name string) {
+	var (
+		cmd        *exec.Cmd
+		isRunning  bool
+		pipeout    io.WriteCloser
+		pipein     io.ReadCloser
+		err        error
+		failDelay  bool
+		killModule bool
+		inChan     chan modules.Message
+		lastPing   time.Time
+	)
+
+	logfunc := func(f string, a ...interface{}) {
+		buf := fmt.Sprintf(f, a...)
+		buf = fmt.Sprintf("[%v] %v", name, buf)
+		ctx.Channels.Log <- mig.Log{Desc: buf}.Info()
+	}
+
+	pingtick := time.Tick(time.Second * 10)
+
+	for {
+		if failDelay {
+			time.Sleep(time.Second * 10)
+			failDelay = false
+		}
+
+		if !isRunning {
+			logfunc("starting module")
+			lastPing = time.Now()
+			cmd = exec.Command(ctx.Agent.BinPath, "-P", strings.ToLower(name))
+			pipeout, err = cmd.StdinPipe()
+			if err != nil {
+				logfunc("error creating stdin pipe, %v", err)
+				failDelay = true
+				continue
+			}
+			pipein, err = cmd.StdoutPipe()
+			if err != nil {
+				logfunc("error creating stdout pipe, %v", err)
+				failDelay = true
+				continue
+			}
+			err = cmd.Start()
+			if err != nil {
+				logfunc("error starting module, %v", err)
+				failDelay = true
+				continue
+			}
+			inChan = make(chan modules.Message, 0)
+
+			go func() {
+				for {
+					msg, err := modules.ReadInput(pipein)
+					if err != nil {
+						logfunc("%v", err)
+						close(inChan)
+						break
+					}
+					inChan <- msg
+				}
+			}()
+
+			isRunning = true
+		}
+		select {
+		case msg, ok := <-inChan:
+			if !ok {
+				err = cmd.Wait()
+				logfunc("module is down, %v", err)
+				isRunning = false
+				failDelay = true
+				break
+			}
+			switch msg.Class {
+			case modules.MsgClassPing:
+				lastPing = time.Now()
+			case modules.MsgClassLog:
+				var lp modules.LogParams
+				buf, err := json.Marshal(msg.Parameters)
+				if err != nil {
+					logfunc("%v", err)
+					break
+				}
+				err = json.Unmarshal(buf, &lp)
+				if err != nil {
+					logfunc("%v", err)
+					break
+				}
+				logfunc("(module log) %v", lp.Message)
+			default:
+				logfunc("unknown message class")
+				killModule = true
+				break
+			}
+		case _ = <-pingtick:
+			// If we haven't received a reply in the past 3 cycles we will
+			// kill the module
+			if time.Now().Sub(lastPing) >= time.Duration(30*time.Second) {
+				logfunc("no ping response from module, killing")
+				killModule = true
+				break
+			}
+
+			pm, err := modules.MakeMessage("ping", nil, false)
+			if err != nil {
+				// Failure here should not occur but does not
+				// mean the module is down
+				logfunc("failed to create ping, %v", err)
+				break
+			}
+			err = modules.WriteOutput(pm, pipeout)
+			if err != nil {
+				logfunc("ping failed, %v", err)
+				isRunning = false
+				failDelay = true
+				break
+			}
+		}
+
+		if killModule {
+			logfunc("killing module")
+			err = cmd.Process.Kill()
+			if err != nil {
+				logfunc("failed to kill module, %v", err)
+				// If this happens we are in a bad state, return from here
+				// as we cannot recover
+				return
+			}
+			_ = cmd.Wait()
+			isRunning = false
+			failDelay = true
+			killModule = false
+		}
+	}
+}

--- a/modules/examplepersist/examplepersist.go
+++ b/modules/examplepersist/examplepersist.go
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package examplepersist /* import "mig.ninja/mig/modules/examplepersist" */
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"time"
+
+	"mig.ninja/mig/modules"
+)
+
+type module struct {
+}
+
+func (m *module) NewRun() modules.Runner {
+	return new(run)
+}
+
+func init() {
+	modules.Register("examplepersist", new(module))
+}
+
+type run struct {
+	Parameters Parameters
+	Results    modules.Result
+}
+
+func buildResults(e elements, r *modules.Result) (buf []byte, err error) {
+	r.Success = true
+	r.Elements = e
+	r.FoundAnything = true
+	buf, err = json.Marshal(r)
+	return
+}
+
+var logChan chan string
+
+func runSomeTasks() {
+	for {
+		time.Sleep(time.Second * 30)
+		// Send a log message up to the agent
+		logChan <- fmt.Sprintf("running, current time is %v", time.Now())
+	}
+}
+
+func requestHandler(p interface{}) (ret string) {
+	var results modules.Result
+	defer func() {
+		if e := recover(); e != nil {
+			results.Errors = append(results.Errors, fmt.Sprintf("%v", e))
+			results.Success = false
+			err, _ := json.Marshal(results)
+			ret = string(err)
+			return
+		}
+	}()
+	// Marshal and unmarshal the parameters into the type we want
+	param := Parameters{}
+	buf, err := json.Marshal(p)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(buf, &param)
+	if err != nil {
+		panic(err)
+	}
+	// Create the response
+	e := elements{String: param.String}
+	resp, err := buildResults(e, &results)
+	if err != nil {
+		panic(err)
+	}
+	return string(resp)
+}
+
+func (r *run) RunPersist(in io.ReadCloser, out io.WriteCloser) {
+	// Create a string channel, used to send log messages up to the agent
+	// from the module tasks
+	logChan = make(chan string, 64)
+	// Start up an example background task
+	go runSomeTasks()
+	_ = os.Remove(modules.PersistSockPath("examplepersist"))
+	l, err := net.Listen("unix", modules.PersistSockPath("examplepersist"))
+	if err != nil {
+		panic(err)
+	}
+	go modules.HandlePersistRequest(l, requestHandler)
+	modules.DefaultPersistHandlers(in, out, logChan)
+}
+
+func (r *run) Run(in io.Reader) (resStr string) {
+	defer func() {
+		if e := recover(); e != nil {
+			// return error in json
+			r.Results.Errors = append(r.Results.Errors, fmt.Sprintf("%v", e))
+			r.Results.Success = false
+			err, _ := json.Marshal(r.Results)
+			resStr = string(err)
+			return
+		}
+	}()
+
+	// Restrict go runtime processor utilization here, this might be moved
+	// into a more generic agent module function at some point.
+	runtime.GOMAXPROCS(1)
+
+	// Read module parameters from stdin
+	err := modules.ReadInputParameters(in, &r.Parameters)
+	if err != nil {
+		panic(err)
+	}
+
+	err = r.ValidateParameters()
+	if err != nil {
+		panic(err)
+	}
+	resStr = modules.SendPersistRequest(r.Parameters, "examplepersist")
+	return
+}
+
+func (r *run) ValidateParameters() (err error) {
+	if r.Parameters.String == "" {
+		return fmt.Errorf("must set a string to echo")
+	}
+	return
+}
+
+func (r *run) PrintResults(result modules.Result, foundOnly bool) (prints []string, err error) {
+	var (
+		elem elements
+	)
+
+	err = result.GetElements(&elem)
+	if err != nil {
+		panic(err)
+	}
+
+	resStr := fmt.Sprintf("echo string was %q", elem.String)
+	prints = append(prints, resStr)
+
+	if !foundOnly {
+		for _, we := range result.Errors {
+			prints = append(prints, we)
+		}
+	}
+
+	return
+}
+
+type elements struct {
+	String string `json:"string"`
+}
+
+type Parameters struct {
+	String string `json:"string"` // String to echo back
+}
+
+func newParameters() *Parameters {
+	return &Parameters{}
+}

--- a/modules/examplepersist/examplepersist_test.go
+++ b/modules/examplepersist/examplepersist_test.go
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package examplepersist /* import "mig.ninja/mig/modules/examplepersist" */
+
+import (
+	"mig.ninja/mig/testutil"
+	"testing"
+)
+
+func TestRegistration(t *testing.T) {
+	testutil.CheckModuleRegistration(t, "examplepersist")
+}

--- a/modules/examplepersist/paramscreator.go
+++ b/modules/examplepersist/paramscreator.go
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package examplepersist /* import "mig.ninja/mig/modules/examplepersist" */
+
+import (
+	"flag"
+	"fmt"
+)
+
+func printHelp(isCmd bool) {
+	dash := ""
+	if isCmd {
+		dash = "-"
+	}
+	fmt.Printf(`Query parameters
+----------------
+%secho <string>     - String to echo back from module
+                    ex: echo testing
+		    Requests examplepersist echo the given string back
+`, dash)
+}
+
+func (r *run) ParamsParser(args []string) (interface{}, error) {
+	var (
+		fs   flag.FlagSet
+		echo string
+	)
+
+	if len(args) < 1 || args[0] == "" || args[0] == "help" {
+		printHelp(true)
+		return nil, nil
+	}
+
+	fs.Init("examplepersist", flag.ContinueOnError)
+	fs.StringVar(&echo, "echo", "", "see help")
+	err := fs.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+
+	p := newParameters()
+	p.String = echo
+
+	r.Parameters = *p
+
+	return r.Parameters, r.ValidateParameters()
+}

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"net"
 	"path"
-	"time"
 )
 
 var ModuleRunDir string
@@ -238,7 +237,6 @@ func WatchForStop(r io.Reader, stopChan *chan bool) error {
 }
 
 func DefaultPersistHandlers(in io.ReadCloser, out io.WriteCloser, logch chan string) {
-	time.Sleep(10 * time.Second)
 	inChan := make(chan Message, 0)
 	go func() {
 		for {

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -308,6 +308,7 @@ var SOCKET string = "127.0.0.1:51664"
 var HEARTBEATFREQ time.Duration = 30 * time.Second
 var REFRESHENV time.Duration = 60 * time.Second
 var MODULETIMEOUT time.Duration = 300 * time.Second
+var SPAWNPERSISTENT bool = true
 var AGENTACL = [...]string{
 \`{
     "default": {


### PR DESCRIPTION
Adds support for persistent modules.

Persistent modules can be used to run background tasks in the agent as a separate process which is managed and kept alive by the agent. The modules run and can keep state over their lifetime, and can be used to perform investigative related tasks across time or execute other continuous functions.

Persistent modules can be queried in the same manner as regular modules using mig-cmd or mig-console. The Run() entry point is still used, but rather than return a result string this function instead interfaces directly with the running module over a domain socket. This removes any need to multiplex requests to the module in the agent itself, runModuleDirectly() is still used for a request which interfaces with the domain socket the persistent module maintains.

The example module periodically logs the current time to the agent, and echos any string sent to it by a client.