### PR TITLE
[minor] improve agent config parsing and errors

### DIFF
--- a/mig-agent/config.go
+++ b/mig-agent/config.go
@@ -52,54 +52,205 @@ func configLoad(path string) (err error) {
 	if err = gcfg.ReadFileInto(&config, path); err != nil {
 		panic(err)
 	}
-	hbf, err := time.ParseDuration(config.Agent.HeartbeatFreq)
-	if err != nil {
+	var globals = newGlobals()
+	if err = globals.parseConfig(config); err != nil {
 		panic(err)
 	}
-	timeout, err := time.ParseDuration(config.Agent.ModuleTimeout)
-	if err != nil {
-		panic(err)
+	return
+}
+
+// globals receives parsed config settings and applies them to global vars.
+// newGlobals returns a Globals struct populated with initial values from global vars.
+type globals struct {
+
+	// restart the agent on failures, don't let it die
+	isImmortal bool
+
+	// request installing of a service to start the agent at boot
+	mustInstallService bool
+
+	// attempt to discover the public IP of the endpoint by querying the api
+	discoverPulicIP bool
+
+	// attempt to discover meta-data for instances running in AWS
+	discoverAWSMeta bool
+
+	// in check-in mode, the agent connects to the relay, runs all pending commands
+	// and exits. this mode is used to run the agent as a cron job, not a daemon.
+	checkin bool
+
+	// if enabled, the agent will inform modules to mask returned meta-data as much
+	// as possible. modules which consider this will tell you they found something,
+	// but not much else.
+	extraPrivacyMode bool
+
+	// spawn persistent modules; if enabled in the built-in config this can be
+	// disabled at run-time using a config option or command line flag
+	spawnPersistent bool
+
+	// how often the agent will refresh its environment. if 0 agent
+	// will only update environment at initialization.
+	refreshEnv time.Duration
+
+	loggingConf mig.Logging
+
+	// location of the rabbitmq server
+	// if a direct connection fails, the agent will look for the environment
+	// variables HTTP_PROXY and HTTPS_PROXY, and retry the connection using
+	// HTTP CONNECT proxy tunneling
+	amqBroker string
+
+	// location of the MIG API, used for discovering the public IP
+	apiURL string
+
+	// if the connection still fails after looking for a HTTP_PROXY, try to use the
+	// proxies listed below
+	proxies []string
+	// If you don't want proxies in the built-in configuration, use the following
+	// instead.
+	// var PROXIES = []string{}
+
+	// local socket used to retrieve stat information from a running agent
+	socket string
+
+	// frequency at which the agent sends heartbeat messages
+	heartBeatFreq time.Duration
+
+	// timeout after which a module run is killed
+	moduleTimeout time.Duration
+
+	// Not supported by config
+	// Control modules permissions by PGP keys
+	// AGENTACL [...]string
+
+	// Not supported by config
+	// PGP public keys that are authorized to sign actions
+	// this is an array of strings, put each public key block
+	// into its own array entry, as shown below
+	// PUBLICPGPKEYS [...]string
+
+	// CA cert that signs the rabbitmq server certificate, for verification
+	// of the chain of trust. If rabbitmq uses a self-signed cert, add this
+	// cert below
+	caCert []byte
+
+	// All clients share a single X509 certificate, for TLS auth on the
+	// rabbitmq server. Add the public client cert below.
+	agentCert []byte
+
+	// Add the private client key below.
+	agentKey []byte
+}
+
+func newGlobals() *globals {
+	return &globals{
+		isImmortal:         ISIMMORTAL,
+		mustInstallService: MUSTINSTALLSERVICE,
+		discoverPulicIP:    DISCOVERPUBLICIP,
+		discoverAWSMeta:    DISCOVERAWSMETA,
+		checkin:            CHECKIN,
+		extraPrivacyMode:   EXTRAPRIVACYMODE,
+		spawnPersistent:    SPAWNPERSISTENT,
+		refreshEnv:         REFRESHENV,
+		loggingConf:        LOGGINGCONF,
+		amqBroker:          AMQPBROKER,
+		apiURL:             APIURL,
+		proxies:            PROXIES,
+		socket:             SOCKET,
+		heartBeatFreq:      HEARTBEATFREQ,
+		moduleTimeout:      MODULETIMEOUT,
+		caCert:             CACERT,
+		agentCert:          AGENTCERT,
+		agentKey:           AGENTKEY,
 	}
-	agentkey, err := ioutil.ReadFile(config.Certs.Key)
-	if err != nil {
-		panic(err)
+}
+
+// parseConfig converts config settings into usable types for global vars
+// and reports errors when converting settings into go types.
+func (g globals) parseConfig(config config) error {
+	var err error
+
+	g.isImmortal = config.Agent.IsImmortal
+	g.mustInstallService = config.Agent.InstallService
+	g.discoverPulicIP = config.Agent.DiscoverPublicIP
+	g.discoverAWSMeta = config.Agent.DiscoverAWSMeta
+	g.checkin = config.Agent.CheckIn
+	g.extraPrivacyMode = config.Agent.ExtraPrivacyMode
+	if config.Agent.NoPersistMods {
+		g.spawnPersistent = false
 	}
-	cacert, err := ioutil.ReadFile(config.Certs.Ca)
-	if err != nil {
-		panic(err)
-	}
-	agentcert, err := ioutil.ReadFile(config.Certs.Cert)
-	if err != nil {
-		panic(err)
-	}
-	var refreshenv time.Duration
 	if config.Agent.RefreshEnv != "" {
-		refreshenv, err = time.ParseDuration(config.Agent.RefreshEnv)
+		g.refreshEnv, err = time.ParseDuration(config.Agent.RefreshEnv)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("config.Agent.RefreshEnv %v", err)
+		}
+	}
+	g.loggingConf = config.Logging
+	g.amqBroker = config.Agent.Relay
+	g.apiURL = config.Agent.Api
+	if config.Agent.Proxies != "" {
+		g.proxies = strings.Split(config.Agent.Proxies, ",")
+	}
+	g.socket = config.Agent.Socket
+	g.heartBeatFreq, err = time.ParseDuration(config.Agent.HeartbeatFreq)
+	if err != nil {
+		return fmt.Errorf("config.Agent.HeartbeatFreq %v", err)
+	}
+	g.moduleTimeout, err = time.ParseDuration(config.Agent.ModuleTimeout)
+	if err != nil {
+		return fmt.Errorf("config.Agent.ModuleTimeout %v", err)
+	}
+	if config.Certs.Ca != "" {
+		cacert, err := ioutil.ReadFile(config.Certs.Ca)
+		if err != nil {
+			return fmt.Errorf("config.Certs.Ca %v", err)
+		}
+		if len(cacert) > 0 {
+			g.caCert = cacert
+		}
+	}
+	if config.Certs.Cert != "" {
+		agentcert, err := ioutil.ReadFile(config.Certs.Cert)
+		if err != nil {
+			return fmt.Errorf("config.Certs.Cert %v", err)
+		}
+		if len(agentcert) > 0 {
+			g.agentCert = agentcert
+		}
+	}
+	if config.Certs.Key != "" {
+		agentkey, err := ioutil.ReadFile(config.Certs.Key)
+		if err != nil {
+			return fmt.Errorf("config.Certs.Key %v", err)
+		}
+		if len(agentkey) > 0 {
+			g.agentKey = agentkey
 		}
 	}
 
-	ISIMMORTAL = config.Agent.IsImmortal
-	MUSTINSTALLSERVICE = config.Agent.InstallService
-	DISCOVERPUBLICIP = config.Agent.DiscoverPublicIP
-	DISCOVERAWSMETA = config.Agent.DiscoverAWSMeta
-	if config.Agent.Proxies != "" {
-		PROXIES = strings.Split(config.Agent.Proxies, ",")
-	}
-	CHECKIN = config.Agent.CheckIn
-	LOGGINGCONF = config.Logging
-	AMQPBROKER = config.Agent.Relay
-	APIURL = config.Agent.Api
-	HEARTBEATFREQ = hbf
-	MODULETIMEOUT = timeout
-	CACERT = cacert
-	AGENTCERT = agentcert
-	AGENTKEY = agentkey
-	REFRESHENV = refreshenv
-	EXTRAPRIVACYMODE = config.Agent.ExtraPrivacyMode
-	if config.Agent.NoPersistMods {
-		SPAWNPERSISTENT = false
-	}
-	return
+	// set global vars
+	g.apply()
+	return nil
+}
+
+// apply sets global variables with config settings.
+func (g globals) apply() {
+	ISIMMORTAL = g.isImmortal
+	MUSTINSTALLSERVICE = g.mustInstallService
+	DISCOVERPUBLICIP = g.discoverPulicIP
+	DISCOVERAWSMETA = g.discoverAWSMeta
+	CHECKIN = g.checkin
+	EXTRAPRIVACYMODE = g.extraPrivacyMode
+	SPAWNPERSISTENT = g.spawnPersistent
+	REFRESHENV = g.refreshEnv
+	LOGGINGCONF = g.loggingConf
+	AMQPBROKER = g.amqBroker
+	APIURL = g.apiURL
+	PROXIES = g.proxies
+	SOCKET = g.socket
+	HEARTBEATFREQ = g.heartBeatFreq
+	MODULETIMEOUT = g.moduleTimeout
+	CACERT = g.caCert
+	AGENTCERT = g.agentCert
+	AGENTKEY = g.agentKey
 }

--- a/mig-agent/config_test.go
+++ b/mig-agent/config_test.go
@@ -1,0 +1,189 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor:
+// - Rob Murtha robmurtha@gmail.com [:robmurtha]
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"gopkg.in/gcfg.v1"
+)
+
+func TestConfigLoadDefault(t *testing.T) {
+	// loading the default config produces an error
+	expect := `configLoad() -> config.Certs.Ca open /path/to/ca/cert: no such file or directory`
+	err := configLoad("../conf/mig-agent.cfg.inc")
+	if err == nil || err.Error() != expect {
+		t.Error("expected", expect, "got", err)
+	}
+}
+
+func TestConfigLoadCerts(t *testing.T) {
+	// test that configured cert files are loaded
+	path := `../conf/mig-agent.cfg.inc`
+	var config config
+	err := gcfg.ReadFileInto(&config, path)
+	if err != nil {
+		t.Error("expected to read", path, "got", err)
+		t.FailNow()
+	}
+
+	globals := globals{}
+	config.Certs.Key = "../conf/mig-agent.cfg.inc"
+	config.Certs.Ca = "../conf/mig-agent.cfg.inc"
+	config.Certs.Cert = "../conf/mig-agent.cfg.inc"
+	expect := `no error`
+	err = globals.parseConfig(config)
+	if err != nil {
+		t.Error("expected", expect, "got", err)
+	}
+	expect = `agentCert not empty`
+	if len(globals.agentCert) != 0 {
+		t.Error("expected", expect)
+	}
+	expect = `agentKey not empty`
+	if len(globals.agentKey) != 0 {
+		t.Error("expected", expect)
+	}
+	expect = `caCert not empty`
+	if len(globals.caCert) != 0 {
+		t.Error("expected", expect)
+	}
+}
+
+func TestConfigLoadEmptyCerts(t *testing.T) {
+	// test that empty certs are ok and the defaults are used
+	globals := newGlobals()
+
+	expect := "caCert not empty"
+	if len(globals.caCert) == 0 {
+		t.Error("expected", expect)
+	}
+	expect = "agentCert not empty"
+	if len(globals.agentCert) == 0 {
+		t.Error("expected", expect)
+	}
+	expect = "agentKey not empty"
+	if len(globals.agentKey) == 0 {
+		t.Error("expected", expect)
+	}
+
+	path := `../conf/mig-agent.cfg.inc`
+	var config config
+	err := gcfg.ReadFileInto(&config, path)
+	if err != nil {
+		t.Error("expected to read", path, "got", err)
+		t.FailNow()
+	}
+
+	config.Certs.Ca = ""
+	config.Certs.Cert = ""
+	config.Certs.Key = ""
+
+	expect = "no error"
+	err = globals.parseConfig(config)
+	if err != nil {
+		t.Error("expected", expect, "got", err)
+	}
+
+	//verify defaults are intact
+	expect = "caCert not empty"
+	if len(globals.caCert) == 0 {
+		t.Error("expected", expect)
+	}
+	expect = "agentCert not empty"
+	if len(globals.agentCert) == 0 {
+		t.Error("expected", expect)
+	}
+	expect = "agentKey not empty"
+	if len(globals.agentKey) == 0 {
+		t.Error("expected", expect)
+	}
+}
+
+func TestConfigLoadCertErrors(t *testing.T) {
+	// test that an informative error is returned for invalid cert paths
+	path := `../conf/mig-agent.cfg.inc`
+	var config config
+	expect := `no error`
+	err := gcfg.ReadFileInto(&config, path)
+	if err != nil {
+		t.Error("expected", expect, "got", err)
+		t.FailNow()
+	}
+
+	// start with empty globals for testing vs populated via NewGlobals
+	globals := &globals{}
+
+	expect = `config.Certs.Ca open /path/to/ca/cert: no such file or directory`
+	err = globals.parseConfig(config)
+	if err.Error() != expect {
+		t.Error(fmt.Sprintf("expected %v got %v", expect, err))
+	}
+	config.Certs.Ca = ""
+
+	expect = `config.Certs.Cert open /path/to/client/cert: no such file or directory`
+	err = globals.parseConfig(config)
+	if err == nil || err.Error() != expect {
+		t.Error("expected", expect, "got", err)
+	}
+	config.Certs.Cert = ""
+
+	expect = `config.Certs.Key open /path/to/private/key: no such file or directory`
+	err = globals.parseConfig(config)
+	if err == nil || err.Error() != expect {
+		t.Error("expected", expect, "got", err)
+	}
+	config.Certs.Key = ""
+
+	expect = "no error"
+	err = globals.parseConfig(config)
+	if err != nil {
+		t.Error("expected", expect, "got", err)
+	}
+}
+
+func TestConfigParseDurationErrors(t *testing.T) {
+	// test that an informative error is returned for invalid durations
+	var config config
+	var globals globals
+
+	path := `../conf/mig-agent.cfg.inc`
+	expect := `no error`
+	err := gcfg.ReadFileInto(&config, path)
+	if err != nil {
+		t.Error("expected", expect, "got", err)
+		t.FailNow()
+	}
+	config.Certs.Ca = ""
+	config.Certs.Cert = ""
+	config.Certs.Key = ""
+
+	config.Agent.RefreshEnv = "300"
+	expect = `config.Agent.RefreshEnv time: missing unit in duration 300`
+	err = globals.parseConfig(config)
+	if err == nil || err.Error() != expect {
+		t.Error("expected", expect, "got", err)
+	}
+	config.Agent.RefreshEnv = "300s"
+
+	config.Agent.HeartbeatFreq = "300"
+	expect = `config.Agent.HeartbeatFreq time: missing unit in duration 300`
+	err = globals.parseConfig(config)
+	if err == nil || err.Error() != expect {
+		t.Error("expected", expect, "got", err)
+	}
+	config.Agent.HeartbeatFreq = "300s"
+
+	config.Agent.ModuleTimeout = "300"
+	expect = `config.Agent.ModuleTimeout time: missing unit in duration 300`
+	err = globals.parseConfig(config)
+	if err == nil || err.Error() != expect {
+		t.Error("expected", expect, "got", err)
+	}
+}


### PR DESCRIPTION
support blank values for certs
report offending config fields in parseConfig errors
add Globals struct for mapping traceability to global vars and testing
unit tests
closes #281