### PR TITLE
[minor] windows fix agent path

### DIFF
--- a/mig-agent/agentcontext/env_windows.go
+++ b/mig-agent/agentcontext/env_windows.go
@@ -106,5 +106,5 @@ exit:
 }
 
 func GetRunDir() string {
-	return `C:\Program Files\mig\`
+	return `C:\mig\`
 }


### PR DESCRIPTION
use C:\mig instead of C:\Program Files\mig\
closes #282