### PR TITLE
[medium] persistent module config file support

### DIFF
--- a/conf/mig-agent-conf.go.inc
+++ b/conf/mig-agent-conf.go.inc
@@ -49,7 +49,7 @@ var SPAWNPERSISTENT = true
 // XXX This should be improved to take into account Windows paths, but at this
 // time persistent module support is not available on Windows. The agent will
 // attempt to locate a configuration using the module name, e.g., modulename.cfg.
-var PERSISTCONFIGDIR = "/etc/mig"
+var MODULECONFIGDIR = "/etc/mig"
 
 // how often the agent will refresh its environment. if 0 agent
 // will only update environment at initialization.

--- a/conf/mig-agent-conf.go.inc
+++ b/conf/mig-agent-conf.go.inc
@@ -5,7 +5,7 @@
 // Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
 package main
 
-import(
+import (
 	"mig.ninja/mig"
 	"time"
 )
@@ -43,13 +43,21 @@ var EXTRAPRIVACYMODE = false
 // disabled at run-time using a config option or command line flag
 var SPAWNPERSISTENT = true
 
+// The directory the agent will look for persistent module configuration files
+// in.
+//
+// XXX This should be improved to take into account Windows paths, but at this
+// time persistent module support is not available on Windows. The agent will
+// attempt to locate a configuration using the module name, e.g., modulename.cfg.
+var PERSISTCONFIGDIR = "/etc/mig"
+
 // how often the agent will refresh its environment. if 0 agent
 // will only update environment at initialization.
 var REFRESHENV time.Duration = 0
 
 var LOGGINGCONF = mig.Logging{
-	Mode:	"stdout",	// stdout | file | syslog
-	Level:	"debug",	// debug | info | ...
+	Mode:  "stdout", // stdout | file | syslog
+	Level: "debug",  // debug | info | ...
 	//File:	"/tmp/migagt.log",
 	//MaxFileSize: 0,
 	//Host:	"syslog_hostname",
@@ -69,6 +77,7 @@ var APIURL string = "http://localhost:1664/api/v1/"
 // if the connection still fails after looking for a HTTP_PROXY, try to use the
 // proxies listed below
 var PROXIES = []string{"proxy.example.net:3128", "proxy2.example.net:8080"}
+
 // If you don't want proxies in the built-in configuration, use the following
 // instead.
 // var PROXIES = []string{}
@@ -84,7 +93,7 @@ var MODULETIMEOUT time.Duration = 300 * time.Second
 
 // Control modules permissions by PGP keys
 var AGENTACL = [...]string{
-`{
+	`{
     "default": {
         "minimumweight": 2,
         "investigators": {
@@ -99,7 +108,7 @@ var AGENTACL = [...]string{
         }
     }
 }`,
-`{
+	`{
     "agentdestroy": {
         "minimumweight": 1,
         "investigators": {
@@ -112,12 +121,11 @@ var AGENTACL = [...]string{
 }`,
 }
 
-
 // PGP public keys that are authorized to sign actions
 // this is an array of strings, put each public key block
 // into its own array entry, as shown below
 var PUBLICPGPKEYS = [...]string{
-`
+	`
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1; Name: User for MIG test (Another test user for Mozilla Investigator) <usertest+mig@example.org>
 
@@ -128,7 +136,7 @@ lMVXz7c/B8T79KIH0EDAG8o6AbvZQdTMSZp+Ap562smLkV+xsPo1O1Zd/hDJKYuY
 =SWyb
 -----END PGP PUBLIC KEY BLOCK-----
 `,
-`
+	`
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1; Name: Test User (This is a test user for Mozilla Investigator) <testuser+mig@example.net>
 
@@ -139,7 +147,6 @@ QnD9SDA9/d80
 =phhK
 -----END PGP PUBLIC KEY BLOCK-----
 `}
-
 
 // CA cert that signs the rabbitmq server certificate, for verification
 // of the chain of trust. If rabbitmq uses a self-signed cert, add this

--- a/mig-agent/config.go
+++ b/mig-agent/config.go
@@ -32,6 +32,7 @@ type config struct {
 		Api              string
 		RefreshEnv       string
 		NoPersistMods    bool
+		PersistConfigDir string
 		ExtraPrivacyMode bool
 	}
 	Certs struct {
@@ -87,6 +88,9 @@ type globals struct {
 	// spawn persistent modules; if enabled in the built-in config this can be
 	// disabled at run-time using a config option or command line flag
 	spawnPersistent bool
+
+	// directory to look in for persistent module configuration files
+	persistConfigDir string
 
 	// how often the agent will refresh its environment. if 0 agent
 	// will only update environment at initialization.
@@ -151,6 +155,7 @@ func newGlobals() *globals {
 		checkin:            CHECKIN,
 		extraPrivacyMode:   EXTRAPRIVACYMODE,
 		spawnPersistent:    SPAWNPERSISTENT,
+		persistConfigDir:   PERSISTCONFIGDIR,
 		refreshEnv:         REFRESHENV,
 		loggingConf:        LOGGINGCONF,
 		amqBroker:          AMQPBROKER,
@@ -178,6 +183,9 @@ func (g globals) parseConfig(config config) error {
 	g.extraPrivacyMode = config.Agent.ExtraPrivacyMode
 	if config.Agent.NoPersistMods {
 		g.spawnPersistent = false
+	}
+	if config.Agent.PersistConfigDir != "" {
+		g.persistConfigDir = config.Agent.PersistConfigDir
 	}
 	if config.Agent.RefreshEnv != "" {
 		g.refreshEnv, err = time.ParseDuration(config.Agent.RefreshEnv)
@@ -242,6 +250,7 @@ func (g globals) apply() {
 	CHECKIN = g.checkin
 	EXTRAPRIVACYMODE = g.extraPrivacyMode
 	SPAWNPERSISTENT = g.spawnPersistent
+	PERSISTCONFIGDIR = g.persistConfigDir
 	REFRESHENV = g.refreshEnv
 	LOGGINGCONF = g.loggingConf
 	AMQPBROKER = g.amqBroker

--- a/mig-agent/config.go
+++ b/mig-agent/config.go
@@ -155,7 +155,7 @@ func newGlobals() *globals {
 		checkin:            CHECKIN,
 		extraPrivacyMode:   EXTRAPRIVACYMODE,
 		spawnPersistent:    SPAWNPERSISTENT,
-		persistConfigDir:   PERSISTCONFIGDIR,
+		persistConfigDir:   MODULECONFIGDIR,
 		refreshEnv:         REFRESHENV,
 		loggingConf:        LOGGINGCONF,
 		amqBroker:          AMQPBROKER,
@@ -250,7 +250,7 @@ func (g globals) apply() {
 	CHECKIN = g.checkin
 	EXTRAPRIVACYMODE = g.extraPrivacyMode
 	SPAWNPERSISTENT = g.spawnPersistent
-	PERSISTCONFIGDIR = g.persistConfigDir
+	MODULECONFIGDIR = g.persistConfigDir
 	REFRESHENV = g.refreshEnv
 	LOGGINGCONF = g.loggingConf
 	AMQPBROKER = g.amqBroker

--- a/mig-agent/configuration.go
+++ b/mig-agent/configuration.go
@@ -49,7 +49,7 @@ var SPAWNPERSISTENT = true
 // XXX This should be improved to take into account Windows paths, but at this
 // time persistent module support is not available on Windows. The agent will
 // attempt to locate a configuration using the module name, e.g., modulename.cfg.
-var PERSISTCONFIGDIR = "/etc/mig"
+var MODULECONFIGDIR = "/etc/mig"
 
 // how often the agent will refresh its environment. if 0 agent
 // will only update environment at initialization.

--- a/mig-agent/configuration.go
+++ b/mig-agent/configuration.go
@@ -5,7 +5,7 @@
 // Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
 package main
 
-import(
+import (
 	"mig.ninja/mig"
 	"time"
 )
@@ -43,13 +43,21 @@ var EXTRAPRIVACYMODE = false
 // disabled at run-time using a config option or command line flag
 var SPAWNPERSISTENT = true
 
+// The directory the agent will look for persistent module configuration files
+// in.
+//
+// XXX This should be improved to take into account Windows paths, but at this
+// time persistent module support is not available on Windows. The agent will
+// attempt to locate a configuration using the module name, e.g., modulename.cfg.
+var PERSISTCONFIGDIR = "/etc/mig"
+
 // how often the agent will refresh its environment. if 0 agent
 // will only update environment at initialization.
 var REFRESHENV time.Duration = 0
 
 var LOGGINGCONF = mig.Logging{
-	Mode:	"stdout",	// stdout | file | syslog
-	Level:	"debug",	// debug | info | ...
+	Mode:  "stdout", // stdout | file | syslog
+	Level: "debug",  // debug | info | ...
 	//File:	"/tmp/migagt.log",
 	//MaxFileSize: 0,
 	//Host:	"syslog_hostname",
@@ -69,6 +77,7 @@ var APIURL string = "http://localhost:1664/api/v1/"
 // if the connection still fails after looking for a HTTP_PROXY, try to use the
 // proxies listed below
 var PROXIES = []string{"proxy.example.net:3128", "proxy2.example.net:8080"}
+
 // If you don't want proxies in the built-in configuration, use the following
 // instead.
 // var PROXIES = []string{}
@@ -84,7 +93,7 @@ var MODULETIMEOUT time.Duration = 300 * time.Second
 
 // Control modules permissions by PGP keys
 var AGENTACL = [...]string{
-`{
+	`{
     "default": {
         "minimumweight": 2,
         "investigators": {
@@ -99,7 +108,7 @@ var AGENTACL = [...]string{
         }
     }
 }`,
-`{
+	`{
     "agentdestroy": {
         "minimumweight": 1,
         "investigators": {
@@ -112,12 +121,11 @@ var AGENTACL = [...]string{
 }`,
 }
 
-
 // PGP public keys that are authorized to sign actions
 // this is an array of strings, put each public key block
 // into its own array entry, as shown below
 var PUBLICPGPKEYS = [...]string{
-`
+	`
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1; Name: User for MIG test (Another test user for Mozilla Investigator) <usertest+mig@example.org>
 
@@ -128,7 +136,7 @@ lMVXz7c/B8T79KIH0EDAG8o6AbvZQdTMSZp+Ap562smLkV+xsPo1O1Zd/hDJKYuY
 =SWyb
 -----END PGP PUBLIC KEY BLOCK-----
 `,
-`
+	`
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1; Name: Test User (This is a test user for Mozilla Investigator) <testuser+mig@example.net>
 
@@ -139,7 +147,6 @@ QnD9SDA9/d80
 =phhK
 -----END PGP PUBLIC KEY BLOCK-----
 `}
-
 
 // CA cert that signs the rabbitmq server certificate, for verification
 // of the chain of trust. If rabbitmq uses a self-signed cert, add this

--- a/mig-agent/persist.go
+++ b/mig-agent/persist.go
@@ -72,7 +72,7 @@ var persistModRegister persistModuleRegister
 // config struct for the module uninitialized.
 func getPersistConfig(modname string) (ret interface{}) {
 	cfg := modules.Available[modname].NewRun().(modules.PersistRunner).PersistModConfig()
-	confpath := path.Join(PERSISTCONFIGDIR, modname+".cfg")
+	confpath := path.Join(MODULECONFIGDIR, modname+".cfg")
 	// An error here isn't fatal, we just continue with cfg as is
 	gcfg.ReadFileInto(cfg, confpath)
 	ret = cfg

--- a/mig-agent/persist.go
+++ b/mig-agent/persist.go
@@ -10,12 +10,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path"
 	"strings"
 	"sync"
 	"time"
 
 	"mig.ninja/mig"
 	"mig.ninja/mig/modules"
+
+	"gopkg.in/gcfg.v1"
 )
 
 // persistModuleRegister maintains a map of the running persistent modules, and
@@ -62,6 +65,19 @@ func (p *persistModuleRegister) remove(modname string) {
 }
 
 var persistModRegister persistModuleRegister
+
+// Load the configuration file for a persistent module if it exists, and return it
+// as a JSON byte slice so we can send it from the agent to the module after the
+// module is started. If the configuration file cannot be loaded, just return the
+// config struct for the module uninitialized.
+func getPersistConfig(modname string) (ret interface{}) {
+	cfg := modules.Available[modname].NewRun().(modules.PersistRunner).PersistModConfig()
+	confpath := path.Join(PERSISTCONFIGDIR, modname+".cfg")
+	// An error here isn't fatal, we just continue with cfg as is
+	gcfg.ReadFileInto(cfg, confpath)
+	ret = cfg
+	return
+}
 
 // Start all the persistent modules available to the agent.
 func startPersist(ctx *Context) (err error) {
@@ -139,6 +155,7 @@ func managePersistModule(ctx *Context, name string) {
 				continue
 			}
 			pipein = modules.NewModuleReader(cmdpipein)
+			cfg := getPersistConfig(name)
 			err = cmd.Start()
 			if err != nil {
 				logfunc("error starting module, %v", err)
@@ -160,6 +177,28 @@ func managePersistModule(ctx *Context, name string) {
 			}()
 
 			isRunning = true
+
+			// The module is now running, send any configuration parameters we have
+			// to it.
+			cm, err := modules.MakeMessageConfig(cfg)
+			if err != nil {
+				// This should never happen, but if it does we will just
+				// kill the executing module as we are unable to send any
+				// configuration to it
+				killModule = true
+				break
+			}
+			err = modules.WriteOutput(cm, pipeout)
+			if err != nil {
+				// XXX This should be revisited, both here and later on when
+				// sending a ping. If this write fails, we just assume the
+				// process is down, where it may not be.
+				logfunc("config write failed, %v", err)
+				isRunning = false
+				persistModRegister.remove(name)
+				failDelay = true
+				continue
+			}
 		}
 		select {
 		case msg, ok := <-inChan:

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -311,6 +311,7 @@ var HEARTBEATFREQ time.Duration = 30 * time.Second
 var REFRESHENV time.Duration = 60 * time.Second
 var MODULETIMEOUT time.Duration = 300 * time.Second
 var SPAWNPERSISTENT bool = true
+var PERSISTCONFIGDIR = "/etc/mig"
 var AGENTACL = [...]string{
 \`{
     "default": {

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -311,7 +311,7 @@ var HEARTBEATFREQ time.Duration = 30 * time.Second
 var REFRESHENV time.Duration = 60 * time.Second
 var MODULETIMEOUT time.Duration = 300 * time.Second
 var SPAWNPERSISTENT bool = true
-var PERSISTCONFIGDIR = "/etc/mig"
+var MODULECONFIGDIR = "/etc/mig"
 var AGENTACL = [...]string{
 \`{
     "default": {


### PR DESCRIPTION
Adds the ability for persistent modules to read a configuration file
that can be used to control their behavior.

In some cases, we may want a persistent module to be configurable. A new
configuration variable PERSISTCONFIGDIR has been added which indicates a
directory the agent will look in for persistent module configs. When the
agent starts a persistent module, it will determine if modulename.cfg
exists in the config directory; if so the agent will load the config and
send it to the newly executed module, which it will read on stdin. The
module can then read this configuration, and configure itself as needed
before it begins it's primary execution functions.

Modules specify the configuration format within the module code itself,
so each module that makes use of this can have it's own configuration
parameters.