### PR TITLE
[medium/bug] resolve bufio issues under high agent/module comms

### DIFF
--- a/client/mig/main.go
+++ b/client/mig/main.go
@@ -244,7 +244,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		out := run.(modules.Runner).Run(bytes.NewBuffer(msg))
+		out := run.(modules.Runner).Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			panic("got empty results, run failed")
 		}

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -255,7 +255,8 @@ func runModuleDirectly(mode string, paramargs interface{}, pretty bool) (out str
 	}
 	// instantiate and call module
 	run := modules.Available[mode].NewRun()
-	out = run.Run(infd)
+	mreader := modules.NewModuleReader(infd)
+	out = run.Run(mreader)
 
 	// if enhanced privacy mode has been requested, apply it to the result set
 	// if the module supports it
@@ -333,7 +334,9 @@ func runModulePersist(mode string) {
 		fmt.Fprint(os.Stdout, string(buf))
 		return
 	}
-	prun.RunPersist(os.Stdin, os.Stdout)
+	sin := modules.NewModuleReader(os.Stdin)
+	sout := modules.NewModuleWriter(os.Stdout)
+	prun.RunPersist(sin, sout)
 }
 
 // runAgentCheckin is the one-off startup function for agent mode, where the

--- a/modules/agentdestroy/agentdestroy.go
+++ b/modules/agentdestroy/agentdestroy.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kardianos/osext"
-	"io"
 	"mig.ninja/mig/modules"
 	"os"
 	"os/exec"
@@ -65,7 +64,7 @@ func (r *run) ValidateParameters() (err error) {
 	return
 }
 
-func (r *run) Run(in io.Reader) (out string) {
+func (r *run) Run(in modules.ModuleReader) (out string) {
 	defer func() {
 		if e := recover(); e != nil {
 			r.Results.Errors = append(r.Results.Errors, fmt.Sprintf("%v", e))

--- a/modules/example/example.go
+++ b/modules/example/example.go
@@ -29,7 +29,6 @@ package example /* import "mig.ninja/mig/modules/example" */
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"mig.ninja/mig/modules"
 	"net"
 	"os"
@@ -90,7 +89,7 @@ func (r *run) ValidateParameters() (err error) {
 // Run *must* be implemented by a module. Its the function that executes the module.
 // It must return a string of marshalled json that contains the results from the module.
 // The code below provides a base module skeleton that can be reused in all modules.
-func (r *run) Run(in io.Reader) (out string) {
+func (r *run) Run(in modules.ModuleReader) (out string) {
 	// a good way to handle execution failures is to catch panics and store
 	// the panicked error into modules.Results.Errors, marshal that, and output
 	// the JSON string back to the caller

--- a/modules/examplepersist/examplepersist.go
+++ b/modules/examplepersist/examplepersist.go
@@ -21,7 +21,6 @@ package examplepersist /* import "mig.ninja/mig/modules/examplepersist" */
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"runtime"
 	"time"
 
@@ -114,7 +113,7 @@ func requestHandler(p interface{}) (ret string) {
 // of the module. It should not return. In this example, we do our initialization
 // and call modules.DefaultPersistHandlers, which looks after handling all
 // persistent module management processes on the module side.
-func (r *run) RunPersist(in io.ReadCloser, out io.WriteCloser) {
+func (r *run) RunPersist(in modules.ModuleReader, out modules.ModuleWriter) {
 	// Create a string channel, used to send log messages up to the agent
 	// from the module tasks. Functions in the persistent module can
 	// log messages through the agent by writing to this channel.
@@ -151,7 +150,7 @@ func (r *run) RunPersist(in io.ReadCloser, out io.WriteCloser) {
 }
 
 // Module Run function, used to make queries using the module.
-func (r *run) Run(in io.Reader) (resStr string) {
+func (r *run) Run(in modules.ModuleReader) (resStr string) {
 	defer func() {
 		if e := recover(); e != nil {
 			// return error in json

--- a/modules/file/file.go
+++ b/modules/file/file.go
@@ -653,7 +653,7 @@ var stats statistics
 
 var walkingErrors []string
 
-func (r *run) Run(in io.Reader) (resStr string) {
+func (r *run) Run(in modules.ModuleReader) (resStr string) {
 	var (
 		roots     []string
 		traversed []string

--- a/modules/file/file_test.go
+++ b/modules/file/file_test.go
@@ -57,7 +57,7 @@ func TestNameSearch(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -90,7 +90,7 @@ func TestContentSearch(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -132,7 +132,7 @@ func TestDecompressedContentSearch(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -163,7 +163,7 @@ func TestSize(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -196,7 +196,7 @@ func TestMTime(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -229,7 +229,7 @@ func TestMode(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -270,7 +270,7 @@ func TestHashes(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Logf("%s\n", msg)
-			out := r.Run(bytes.NewBuffer(msg))
+			out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 			if len(out) == 0 {
 				t.Fatal("run failed")
 			}
@@ -311,7 +311,7 @@ func TestDecompressedHash(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -346,7 +346,7 @@ func TestAllHashes(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -378,7 +378,7 @@ func TestMaxDepth(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("%s\n", msg)
-	out := r.Run(bytes.NewBuffer(msg))
+	out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 	if len(out) == 0 {
 		t.Fatal("run failed")
 	}
@@ -448,7 +448,7 @@ func TestMacroal(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}
@@ -596,7 +596,7 @@ func TestMismatch(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("%s\n", msg)
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}

--- a/modules/memory/memory.go
+++ b/modules/memory/memory.go
@@ -19,7 +19,6 @@ import (
 	"github.com/mozilla/masche/listlibs"
 	"github.com/mozilla/masche/memaccess"
 	"github.com/mozilla/masche/process"
-	"io"
 	"mig.ninja/mig/modules"
 	"regexp"
 	"time"
@@ -302,7 +301,7 @@ func validateBytes(bytes string) error {
 	return nil
 }
 
-func (r *run) Run(in io.Reader) (out string) {
+func (r *run) Run(in modules.ModuleReader) (out string) {
 	var ts statistics
 	stats = ts
 	// in debug mode, we just panic

--- a/modules/memory/memory_test.go
+++ b/modules/memory/memory_test.go
@@ -74,7 +74,7 @@ func TestFindGoTestProcess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	out := r.Run(bytes.NewBuffer(msg))
+	out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 	if len(out) == 0 {
 		t.Fatal("run failed")
 	}
@@ -123,7 +123,7 @@ func TestSearches(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		out := r.Run(bytes.NewBuffer(msg))
+		out := r.Run(modules.NewModuleReader(bytes.NewBuffer(msg)))
 		if len(out) == 0 {
 			t.Fatal("run failed")
 		}

--- a/modules/netstat/netstat.go
+++ b/modules/netstat/netstat.go
@@ -12,7 +12,6 @@ package netstat /* import "mig.ninja/mig/modules/netstat" */
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"regexp"
 	"strconv"
@@ -167,7 +166,7 @@ func validatePort(val string) error {
 	return nil
 }
 
-func (r *run) Run(in io.Reader) (resStr string) {
+func (r *run) Run(in modules.ModuleReader) (resStr string) {
 	defer func() {
 		if e := recover(); e != nil {
 			// return error in json

--- a/modules/ping/ping.go
+++ b/modules/ping/ping.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"io"
 	"mig.ninja/mig/modules"
 	"net"
 	"os"
@@ -62,7 +61,7 @@ const (
 	E_Timeout     = "connection timed out"
 )
 
-func (r *run) Run(in io.Reader) (out string) {
+func (r *run) Run(in modules.ModuleReader) (out string) {
 	var (
 		err error
 		el  elements

--- a/modules/pkg/pkg.go
+++ b/modules/pkg/pkg.go
@@ -9,7 +9,6 @@ package pkg /* import "mig.ninja/mig/modules/pkg" */
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"regexp"
 	"runtime"
 	"time"
@@ -62,7 +61,7 @@ func buildResults(e elements, r *modules.Result) (buf []byte, err error) {
 	return
 }
 
-func (r *run) Run(in io.Reader) (resStr string) {
+func (r *run) Run(in modules.ModuleReader) (resStr string) {
 	defer func() {
 		if e := recover(); e != nil {
 			// return error in json

--- a/modules/scribe/scribe.go
+++ b/modules/scribe/scribe.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"runtime"
 	"strconv"
 	"time"
@@ -93,7 +92,7 @@ func fileModuleLocator(pattern string, regex bool, root string, depth int) ([]st
 	if err != nil {
 		return ret, nil
 	}
-	rdr := bytes.NewReader(buf)
+	rdr := modules.NewModuleReader(bytes.NewReader(buf))
 
 	res := run.Run(rdr)
 	var modresult modules.Result
@@ -118,7 +117,7 @@ func fileModuleLocator(pattern string, regex bool, root string, depth int) ([]st
 	return ret, nil
 }
 
-func (r *run) Run(in io.Reader) (resStr string) {
+func (r *run) Run(in modules.ModuleReader) (resStr string) {
 	defer func() {
 		if e := recover(); e != nil {
 			// return error in json

--- a/modules/timedrift/timedrift.go
+++ b/modules/timedrift/timedrift.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"mig.ninja/mig/modules"
 	"net"
 	"os"
@@ -79,7 +78,7 @@ func (r *run) ValidateParameters() (err error) {
 	return err
 }
 
-func (r *run) Run(in io.Reader) (out string) {
+func (r *run) Run(in modules.ModuleReader) (out string) {
 	var (
 		stats   statistics
 		el      elements

--- a/modules/upgrade/upgrade.go
+++ b/modules/upgrade/upgrade.go
@@ -87,7 +87,7 @@ func (r run) ValidateParameters() (err error) {
 	return
 }
 
-func (r run) Run(in io.Reader) (out string) {
+func (r run) Run(in modules.ModuleReader) (out string) {
 	defer func() {
 		if e := recover(); e != nil {
 			r.Results.Errors = append(r.Results.Errors, fmt.Sprintf("%v", e))


### PR DESCRIPTION
When a message between a module and the agent is read by either,
ReadInput is used which uses buffered IO to read a single line. A bug
existed here where a new bufio Reader was being allocated each time.

Under normal circumstances there would be no issue, since a single line
is generally sent to the module from the agent and read. However, in a
case where a large number of messages were being exchanged between the
agent and the module (e.g., persistent modules) it was possible the
bufio reader could have buffered more than one line. Since a new buffer
was being allocated each time, this resulted in loss of partial message
data, and usually ended up generating JSON unmarshaling errors since
part of the JSON structure was missing.

This was resolved by introducing a new ModuleReader and ModuleWriter
type that is used to read/write between the agent and modules.
ModuleReader allocates the buffered reader on creation once, so we only
ever have the single buffered reader for the lifetime of the module
execution.