### PR TITLE
[minor] remove reference to setadmin from mig-console

### DIFF
--- a/client/mig-console/investigator.go
+++ b/client/mig-console/investigator.go
@@ -91,7 +91,6 @@ pubkey			  show the armored public key of the investigator
 r			  refresh the investigator (get latest version from upstream)
 setperms [permissions...] set permissions for investigator, no arguments to apply default
 showperms                 display possible permission values
-setadmin <true|false>     enable or disable admin flag for investigator
 setstatus <status>	  changes the status of the investigator to <status> (can be 'active' or 'disabled')
 `)
 		case "lastactions":

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -757,7 +757,7 @@ POST /api/v1/investigator/create/
 * Parameters: (POST body)
         - `name`: string that represents the full name
         - `publickey`: armored GPG public key
-        - `isadmin`: specify if user should be admin, true or false
+        - `permissions`: JSON marshaled mig.InvestigatorPerms data
 * Response Code: 201 Created
 * Response: Collection+JSON
 * Example: (without authentication)
@@ -765,7 +765,7 @@ POST /api/v1/investigator/create/
 .. code:: bash
 
 	$ gpg --export -a --export-options export-minimal bob_kelso@example.net > /tmp/bobpubkey
-	$ curl -iv -F "name=Bob Kelso" -F "isadmin=false" -F publickey=@/tmp/pubkey https://api.mig.example.net/api/v1/investigator/create/
+	$ curl -iv -F "name=Bob Kelso" -F  -F 'permissions={"search":true,"dashboard":true}' -F publickey=@/tmp/pubkey https://api.mig.example.net/api/v1/investigator/create/
 
 POST /api/v1/investigator/update/
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -774,12 +774,12 @@ POST /api/v1/investigator/update/
 * Parameters: (POST body)
         - `id`: investigator id, to identify the target investigator
         - `status`: new status of the investigator, to be updated
-        - `isadmin`: specify if user should be admin, true or false
+        - `permissions`: JSON marshaled mig.InvestigatorPerms data
 * Response Code: 201 Created
 * Response: Collection+JSON
 * Example: (without authentication)
 
-One of either ``status`` or ``isadmin`` must be passed to this API endpoint.
+One of either ``status`` or ``permissions`` must be passed to this API endpoint.
 
 .. code:: bash
 


### PR DESCRIPTION
setadmin in mig-console was replaced by setperms; remove an old
reference to it in the help output. Also removes some references to
isadmin that were still present in API documentation.

Closes #312