### PR TITLE
Better correlation between loader/agent instances and action logging

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -24,6 +24,7 @@ type Agent struct {
 	Mode            string      `json:"mode"`
 	Version         string      `json:"version,omitempty"`
 	PID             int         `json:"pid,omitempty"`
+	LoaderName      string      `json:"loadername,omitempty"`
 	StartTime       time.Time   `json:"starttime,omitempty"`
 	DestructionTime time.Time   `json:"destructiontime,omitempty"`
 	HeartBeatTS     time.Time   `json:"heartbeatts,omitempty"`

--- a/conf/scheduler.cfg.inc
+++ b/conf/scheduler.cfg.inc
@@ -20,6 +20,9 @@
     ; issue kill orders to duplicate agents running on the same endpoint
     killdupagents = false
 
+    ; include an entry in log each time an action is sent to an agent
+    logactions = false
+
 ; the collector continuously pulls
 ; pending messages from the spool
 [collector]

--- a/database/loader.go
+++ b/database/loader.go
@@ -70,9 +70,10 @@ func (db *DB) UpdateLoaderEntry(lid float64, agt mig.Agent) (err error) {
 	}
 	_, err = db.c.Exec(`UPDATE loaders
 		SET name=$1, env=$2, tags=$3,
+		queueloc=NULLIF($4, ''),
 		lastseen=now()
-		WHERE id=$4`,
-		agt.Name, jEnv, jTags, lid)
+		WHERE id=$5`,
+		agt.Name, jEnv, jTags, agt.QueueLoc, lid)
 	if err != nil {
 		return err
 	}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -31,7 +31,8 @@ CREATE TABLE agents (
     refreshtime         timestamp with time zone NOT NULL,
     status              character varying(255),
     environment         json,
-    tags                json
+    tags                json,
+    loadername          character varying(2048)
 );
 ALTER TABLE public.agents OWNER TO migadmin;
 ALTER TABLE ONLY agents

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -141,13 +141,15 @@ CREATE TABLE loaders (
 	tags          json,
 	lastseen      timestamp with time zone NOT NULL,
 	enabled       boolean NOT NULL DEFAULT false,
-	expectenv     character varying(2048)
+	expectenv     character varying(2048),
+	queueloc      character varying(2048)
 );
 ALTER TABLE ONLY loaders
     ADD CONSTRAINT loaders_pkey PRIMARY KEY (id);
 CREATE UNIQUE INDEX loaders_loadername_idx ON loaders USING btree(loadername);
 CREATE UNIQUE INDEX loaders_loaderkey_idx ON loaders USING btree(loaderkey);
 CREATE UNIQUE INDEX loaders_keyprefix_idx ON loaders USING btree(keyprefix);
+CREATE UNIQUE INDEX loaders_queueloc_idx ON loaders USING btree(queueloc);
 ALTER TABLE public.loaders OWNER TO migadmin;
 
 CREATE TABLE modules (
@@ -208,7 +210,7 @@ GRANT INSERT ON actions, signatures, manifests, manifestsig, loaders TO migapi;
 GRANT DELETE ON manifestsig TO migapi;
 GRANT INSERT (name, pgpfingerprint, publickey, status, createdat, lastmodified, permissions) ON investigators TO migapi;
 GRANT UPDATE (permissions, status, lastmodified) ON investigators TO migapi;
-GRANT UPDATE (name, env, tags, loaderkey, salt, lastseen, enabled, expectenv) ON loaders TO migapi;
+GRANT UPDATE (name, env, tags, loaderkey, salt, lastseen, enabled, expectenv, queueloc) ON loaders TO migapi;
 GRANT UPDATE (status) ON manifests TO migapi;
 GRANT USAGE ON SEQUENCE investigators_id_seq TO migapi;
 GRANT USAGE ON SEQUENCE loaders_id_seq TO migapi;
@@ -218,7 +220,7 @@ GRANT USAGE ON SEQUENCE manifests_id_seq TO migapi;
 CREATE ROLE migreadonly;
 ALTER ROLE migreadonly WITH NOSUPERUSER INHERIT NOCREATEROLE NOCREATEDB NOLOGIN;
 GRANT SELECT ON actions, agents, agtmodreq, commands, invagtmodperm, modules, signatures TO migreadonly;
-GRANT SELECT (id, env, tags, expectenv) ON loaders TO migreadonly;
+GRANT SELECT (id, env, tags, expectenv, loadername, queueloc) ON loaders TO migreadonly;
 GRANT SELECT (id, name, pgpfingerprint, publickey, status, createdat, lastmodified) ON investigators TO migreadonly;
 GRANT migreadonly TO migapi;
 GRANT migreadonly TO migscheduler;

--- a/mig-agent/agentcontext/agent-context.go
+++ b/mig-agent/agentcontext/agent-context.go
@@ -85,6 +85,7 @@ func (ctx *AgentContext) Differs(comp AgentContext) bool {
 
 func (ctx *AgentContext) ToAgent() (ret mig.Agent) {
 	ret.Name = ctx.Hostname
+	ret.QueueLoc = ctx.QueueLoc
 	ret.PID = os.Getpid()
 	ret.Env.OS = ctx.OS
 	ret.Env.Arch = ctx.Architecture

--- a/mig-agent/agentcontext/agent-context.go
+++ b/mig-agent/agentcontext/agent-context.go
@@ -14,10 +14,15 @@ package agentcontext /* import "mig.ninja/mig/mig-agent/agentcontext" */
 import (
 	"fmt"
 	"github.com/kardianos/osext"
+	"io/ioutil"
+	mrand "math/rand"
 	"mig.ninja/mig"
 	"os"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // Information from the system the agent is running on
@@ -31,6 +36,7 @@ type AgentContext struct {
 	Architecture string   // System architecture
 	Addresses    []string // IP addresses
 	PublicIP     string   // Systems public IP from perspective of API
+	UID          string   // Agent ID
 
 	AWS AWSContext // AWS specific information
 }
@@ -140,6 +146,10 @@ func NewAgentContext(lch chan mig.Log, hints AgentContextHints) (ret AgentContex
 	if err != nil {
 		panic(err)
 	}
+	ret, err = initAgentID(ret)
+	if err != nil {
+		panic(err)
+	}
 
 	if hints.DiscoverPublicIP {
 		ret, err = findPublicIP(ret, hints)
@@ -155,6 +165,108 @@ func NewAgentContext(lch chan mig.Log, hints AgentContextHints) (ret AgentContex
 		}
 	}
 
+	return
+}
+
+// initAgentID will retrieve an ID from disk, or request one if missing
+func initAgentID(orig_ctx AgentContext) (ctx AgentContext, err error) {
+	ctx = orig_ctx
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("initAgentID() -> %v", e)
+		}
+		logChan <- mig.Log{Desc: "leaving initAgentID()"}.Debug()
+	}()
+	os.Chmod(ctx.RunDir, 0755)
+	idFile := ctx.RunDir + ".migagtid"
+	id, err := ioutil.ReadFile(idFile)
+	if err != nil {
+		logChan <- mig.Log{Desc: fmt.Sprintf("unable to read agent id from '%s': %v", idFile, err)}.Debug()
+		// ID file doesn't exist, create it
+		id, err = createIDFile(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}
+	// Make sure the obtained queue location matches the format that we expect, if
+	// it doesn't create a new one
+	mtch, err := regexp.Match("^[0-9a-zA-Z]{80,}$", id)
+	if err != nil {
+		panic(err)
+	}
+	if !mtch {
+		logChan <- mig.Log{Desc: "invalid or deprecated agent ID, recreating"}.Info()
+		id, err = createIDFile(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}
+	ctx.UID = fmt.Sprintf("%s", id)
+	os.Chmod(idFile, 0400)
+	return
+}
+
+// createIDFile will generate a new ID for this agent and store it on disk
+// the location depends on the operating system
+func createIDFile(ctx AgentContext) (id []byte, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("createIDFile() -> %v", e)
+		}
+	}()
+	// generate an ID with 512 bits of entropy
+	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	var sid string
+	for i := 0; i < 8; i++ {
+		sid += strconv.FormatUint(uint64(r.Int63()), 36)
+	}
+
+	// check that the storage DIR exist, and that it's a dir
+	tdir, err := os.Open(ctx.RunDir)
+	defer tdir.Close()
+	if err != nil {
+		// dir doesn't exist, create it
+		logChan <- mig.Log{Desc: fmt.Sprintf("agent rundir is missing from '%s'. creating it", ctx.RunDir)}.Debug()
+		err = os.MkdirAll(ctx.RunDir, 0755)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		// open worked, verify that it's a dir
+		tdirMode, err := tdir.Stat()
+		if err != nil {
+			panic(err)
+		}
+		if !tdirMode.Mode().IsDir() {
+			logChan <- mig.Log{Desc: fmt.Sprintf("'%s' is not a directory. removing it", ctx.RunDir)}.Debug()
+			// not a valid dir. destroy whatever it is, and recreate
+			err = os.Remove(ctx.RunDir)
+			if err != nil {
+				panic(err)
+			}
+			err = os.MkdirAll(ctx.RunDir, 0755)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	idFile := ctx.RunDir + ".migagtid"
+
+	// something exists at the location of the id file, just plain remove it
+	_ = os.Remove(idFile)
+
+	// write the ID file
+	err = ioutil.WriteFile(idFile, []byte(sid), 0400)
+	if err != nil {
+		panic(err)
+	}
+	// read ID from disk
+	id, err = ioutil.ReadFile(idFile)
+	if err != nil {
+		panic(err)
+	}
+	logChan <- mig.Log{Desc: fmt.Sprintf("agent id created in '%s'", idFile)}.Debug()
 	return
 }
 

--- a/mig-agent/agentcontext/agent-context.go
+++ b/mig-agent/agentcontext/agent-context.go
@@ -37,6 +37,7 @@ type AgentContext struct {
 	Addresses    []string // IP addresses
 	PublicIP     string   // Systems public IP from perspective of API
 	UID          string   // Agent ID
+	QueueLoc     string   // Agent queue location
 
 	AWS AWSContext // AWS specific information
 }
@@ -150,6 +151,9 @@ func NewAgentContext(lch chan mig.Log, hints AgentContextHints) (ret AgentContex
 	if err != nil {
 		panic(err)
 	}
+
+	// build the agent message queue location
+	ret.QueueLoc = fmt.Sprintf("%s.%s", ret.OS, ret.UID)
 
 	if hints.DiscoverPublicIP {
 		ret, err = findPublicIP(ret, hints)

--- a/mig-agent/context.go
+++ b/mig-agent/context.go
@@ -191,8 +191,8 @@ func Init(foreground, upgrade bool) (ctx Context, err error) {
 	// get the agent ID
 	ctx.Agent.UID = actx.UID
 
-	// build the agent message queue location
-	ctx.Agent.QueueLoc = fmt.Sprintf("%s.%s", ctx.Agent.Env.OS, ctx.Agent.UID)
+	// set the agent message queue location
+	ctx.Agent.QueueLoc = actx.QueueLoc
 
 	// daemonize if not in foreground mode
 	if !foreground {

--- a/mig-scheduler/context.go
+++ b/mig-scheduler/context.go
@@ -33,6 +33,7 @@ type Context struct {
 		// configuration
 		TimeOut, HeartbeatFreq, Whitelist string
 		DetectMultiAgents, KillDupAgents  bool
+		LogActions                        bool
 	}
 	Channels struct {
 		// internal

--- a/mig-scheduler/logging.go
+++ b/mig-scheduler/logging.go
@@ -12,7 +12,7 @@ import (
 
 func logAgentAction(ctx Context, cmd mig.Command) (err error) {
 	var logmsg string
-	logmsg = fmt.Sprintf("Agent action: %q %q %q", cmd.Agent.Name, cmd.Agent.LoaderName, cmd.Action.Name)
+	logmsg = fmt.Sprintf("Agent action: agent=%q loader=%q name=%q", cmd.Agent.Name, cmd.Agent.LoaderName, cmd.Action.Name)
 	ctx.Channels.Log <- mig.Log{OpID: ctx.OpID, ActionID: cmd.Action.ID, CommandID: cmd.ID, Desc: logmsg}.Info()
 	return
 }

--- a/mig-scheduler/logging.go
+++ b/mig-scheduler/logging.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+package main
+
+import (
+	"fmt"
+	"mig.ninja/mig"
+)
+
+func logAgentAction(ctx Context, cmd mig.Command) (err error) {
+	var logmsg string
+	logmsg = fmt.Sprintf("Agent action: %q %q %q", cmd.Agent.Name, cmd.Agent.LoaderName, cmd.Action.Name)
+	ctx.Channels.Log <- mig.Log{OpID: ctx.OpID, ActionID: cmd.Action.ID, CommandID: cmd.ID, Desc: logmsg}.Info()
+	return
+}

--- a/mig-scheduler/scheduler.go
+++ b/mig-scheduler/scheduler.go
@@ -179,6 +179,12 @@ func createCommand(ctx Context, action mig.Action, agent mig.Agent, emptyResults
 	cmd.ID = cmdid
 	cmd.StartTime = time.Now().UTC()
 	cmd.Results = emptyResults
+	if ctx.Agent.LogActions {
+		err = logAgentAction(ctx, cmd)
+		if err != nil {
+			panic(err)
+		}
+	}
 	ctx.Channels.CommandReady <- cmd
 	return
 }


### PR DESCRIPTION
Adds an option to the scheduler to log a summary of each command dispatched to an agent. This summary will include the name of the loader instance associated with the agent, if one is present.

To do this, agent ID (e.g., .migagtid) related functionality was moved into agentcontext so it could be used by both the loader and the agent. The loader now sends the agent ID with its requests, which will be the same ID the agent is using for queue location to allow correlation between the instances.