### PR TITLE
pinentry runPass doesn't disable echo

### DIFF
--- a/pgp/pinentry/pinentry.go
+++ b/pgp/pinentry/pinentry.go
@@ -120,8 +120,14 @@ func (r *Request) GetPIN() (pin string, outerr error) {
 
 func runPass(bin string, args ...string) {
 	cmd := exec.Command(bin, args...)
+	cmd.Stdin  = os.Stdin
 	cmd.Stdout = os.Stdout
-	cmd.Run()
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("==> Error: %s\n", err.Error())
+	}
+	return "", nil;
 }
 
 func (r *Request) getPINNaïve() (string, error) {
@@ -129,7 +135,10 @@ func (r *Request) getPINNaïve() (string, error) {
 	if err != nil {
 		return "", errors.New("no pinentry or stty found")
 	}
-	runPass(stty, "-echo")
+	ret, err := runPass(stty, "-echo")
+	if err != nil {
+		os.Stderr.WriteString(err)
+	}
 	defer runPass(stty, "echo")
 
 	if r.Desc != "" {


### PR DESCRIPTION
https://github.com/camlistore/camlistore/issues/897

I was hoping to fix this upstream and then have this get pulled down, but there's more hoops than I can reasonably jump through, not being a Go programmer.

Running mig in a minimal environment leaves my password being echoed back on the screen, which is bad.  If you can improve this or get it upstream, have at it.