### PR TITLE
WIP [medium] mig-cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,13 @@ bin/*
 conf/*
 !conf/*.inc
 !conf/mig-agent-installer.wxs
+!conf/mig-loader-installer.wxs
 mig-agent/configuration.go
 */available_modules.go
 */*/available_modules.go
 */*/*/available_modules.go
 !conf/available_modules.go
+!conf/config_windows.go
 *.a
 *.so
 *.o

--- a/conf/mig-loader-installer.wxs
+++ b/conf/mig-loader-installer.wxs
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<?define ProductVersion = "REPLACE_WITH_MIG_LOADER_VERSION"?>
+<?define ProductUpgradeCode = "00e305bd-5758-4c13-b3da-80cda1c5517e"?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+
+	<Product Name='Mozilla InvestiGator Loader'
+			 Version='$(var.ProductVersion)'
+			 Id='4a53b243-8405-4a1f-a85a-05cd21428206'
+			 UpgradeCode='$(var.ProductUpgradeCode)'
+			 Language='1033'
+			 Manufacturer='Mozilla'>
+
+		<Package Comments='MIG Loader' InstallerVersion='100' Compressed='yes'/>
+
+		<Media Id='1' Cabinet='product.cab' EmbedCab='yes' />
+
+		<Property Id="ARPHELPLINK"	  Value="http://mig.mozilla.org"/>
+		<Property Id="ARPURLINFOABOUT"  Value="http://mig.mozilla.org"/>
+		<Property Id="ARPNOREPAIR"	  Value="1"/>
+		<Property Id="ARPNOMODIFY"	  Value="1"/>
+
+		<Upgrade Id="$(var.ProductUpgradeCode)">
+			<UpgradeVersion Minimum="$(var.ProductVersion)"
+							OnlyDetect="yes"
+							Property="NEWERVERSIONDETECTED"/>
+			<UpgradeVersion Minimum="00000000-0"
+							Maximum="$(var.ProductVersion)"
+							IncludeMinimum="yes"
+							IncludeMaximum="no"
+							Property="OLDERVERSIONBEINGUPGRADED"/>
+		</Upgrade>
+		<Condition Message="A newer version of this software is already installed.">NOT NEWERVERSIONDETECTED</Condition>
+
+		<Directory Id='TARGETDIR' Name='SourceDir'>
+			<Directory Id='ProgramFiles64Folder'>
+				<Directory Id='INSTALLDIR' Name='mig'>
+                    <Component Id='MainExecutable' Guid='9525c416-04b8-4bed-9567-ff6fb7dd4ea9'>
+                        <File Name='mig-loader-$(var.ProductVersion).exe'
+                              Id='MIGALoaderBinary'
+                              DiskId='1'
+                              Source='mig-loader-$(var.ProductVersion).exe'
+                              KeyPath='yes'/>
+                    </Component>
+                    <Component Id='MainExecutableShortcut' Guid='1ee43c48-8f05-4a1f-9745-ee1849018d3e'>
+			    <Shortcut Id='MIGLoaderShortcut'
+				    Name='mig-loader.exe'
+				    Description='MIG Loader'
+				    Target='[#MIGLoaderBinary]'
+				    WorkingDirectory='INSTALLDIR' />
+                    </Component>
+			    </Directory>
+			</Directory>
+		</Directory>
+
+		<Feature Id='Complete' Level='1'>
+			<ComponentRef Id='MainExecutable' />
+			<ComponentRef Id='MainExecutableShortcut' />
+		</Feature>
+	</Product>
+</Wix>

--- a/constants.go
+++ b/constants.go
@@ -21,4 +21,8 @@ const (
 
 	// dummy queue for scheduler heartbeats to the relays
 	Ev_Q_Sched_Hb = "scheduler.heartbeat"
+
+	// environment variables
+	Env_Win_Root        = "ProgramFiles(x86)"
+	Env_Win_Root_Defaut = "C:/Program Files (x86)"
 )

--- a/manifest.go
+++ b/manifest.go
@@ -363,6 +363,8 @@ var bundleEntryLinux = []BundleDictionaryEntry{
 	{"agentcert", "/etc/mig/agent.crt", "", 0644},
 	{"agentkey", "/etc/mig/agent.key", "", 0600},
 	{"cacert", "/etc/mig/ca.crt", "", 0644},
+	{"mig-cron", "/sbin/mig-cron", "", 0700},
+	{"configuration-cron", "/etc/mig/mig-cron.cfg", "", 0600},
 }
 
 var bundleEntryDarwin = []BundleDictionaryEntry{
@@ -372,11 +374,25 @@ var bundleEntryDarwin = []BundleDictionaryEntry{
 	{"agentcert", "/etc/mig/agent.crt", "", 0644},
 	{"agentkey", "/etc/mig/agent.key", "", 0600},
 	{"cacert", "/etc/mig/ca.crt", "", 0644},
+	{"mig-cron", "/usr/local/bin/mig-cron", "", 0700},
+	{"configuration-cron", "/etc/mig/mig-cron.cfg", "", 0600},
+}
+
+var bundleEntryWindows = []BundleDictionaryEntry{
+	{"mig-agent", Env_Win_Root_Defaut + "/mig/mig-agent", "", 0700},
+	{"mig-loader", Env_Win_Root_Defaut + "/mig/mig-loader", "", 0700},
+	{"configuration", Env_Win_Root_Defaut + "/mig/mig/mig-agent.cfg", "", 0600},
+	{"agentcert", Env_Win_Root_Defaut + "/mig/agent.crt", "", 0644},
+	{"agentkey", Env_Win_Root_Defaut + "/mig/agent.key", "", 0600},
+	{"cacert", Env_Win_Root_Defaut + "/mig/ca.crt", "", 0644},
+	{"mig-cron", Env_Win_Root_Defaut + "/mig/mig-cron.exe", "", 0700},
+	{"configuration-cron", Env_Win_Root_Defaut + "/mig/mig-cron.cfg", "", 0600},
 }
 
 var BundleDictionary = map[string][]BundleDictionaryEntry{
-	"linux":  bundleEntryLinux,
-	"darwin": bundleEntryDarwin,
+	"linux":   bundleEntryLinux,
+	"darwin":  bundleEntryDarwin,
+	"windows": bundleEntryWindows,
 }
 
 func GetHostBundle() ([]BundleDictionaryEntry, error) {
@@ -385,6 +401,8 @@ func GetHostBundle() ([]BundleDictionaryEntry, error) {
 		return bundleEntryLinux, nil
 	case "darwin":
 		return bundleEntryDarwin, nil
+	case "windows":
+		return bundleEntryWindows, nil
 	}
 	return nil, fmt.Errorf("no entry for %v in bundle dictionary", runtime.GOOS)
 }

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -1,4 +1,5 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
@@ -79,12 +80,15 @@ func main() {
 	}
 	runtime.GOMAXPROCS(cpus)
 
+	// platform specific defaults
+	setPlatformDefaults(&runOpt)
+
 	// parse command line argument
 	// -m selects the mode {agent, filechecker, ...}
 	flag.BoolVar(&runOpt.debug, "d", false, "Debug mode: run in foreground, log to stdout.")
 	flag.StringVar(&runOpt.mode, "m", "agent", "Module to run (eg. agent, filechecker).")
 	flag.StringVar(&runOpt.file, "i", "/path/to/file", "Load action from file.")
-	flag.StringVar(&runOpt.config, "c", "/etc/mig/mig-agent.cfg", "Load configuration from file.")
+	flag.StringVar(&runOpt.config, "c", runOpt.config, "Load configuration from file.")
 	flag.StringVar(&runOpt.query, "q", "somequery", "Send query to the agent's socket, print response to stdout and exit.")
 	flag.BoolVar(&runOpt.foreground, "f", false, "Agent will fork into background by default. Except if this flag is set.")
 	flag.BoolVar(&runOpt.upgrading, "u", false, "Used while upgrading an agent, means that this agent is started by another agent.")

--- a/mig-agent/defaults.go
+++ b/mig-agent/defaults.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path"
+	"runtime"
+
+	"mig.ninja/mig"
+)
+
+func setPlatformDefaults(runOpt *runtimeOptions) {
+	// platform fallback defaults
+	runOpt.config = "/etc/mig/mig-agent.cfg"
+
+	if runtime.GOOS == `windows` {
+		setWindowsDefaults(runOpt)
+	}
+}
+
+func setWindowsDefaults(runOpt *runtimeOptions) {
+	root := os.Getenv(mig.Env_Win_Root)
+	if root != "" && root != mig.Env_Win_Root_Defaut {
+		// setup non default paths
+		runOpt.config = path.Join(root, "mig", "mig-agent.cfg")
+	}
+	return
+}

--- a/mig-cron/cron.go
+++ b/mig-cron/cron.go
@@ -1,0 +1,244 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Rob Murtha robmurtha@gmail.com [:robmurtha]
+package main
+
+import (
+	"flag"
+	"os"
+	"path"
+	"runtime"
+	"sync"
+	"time"
+
+	"log"
+
+	"os/exec"
+
+	"io/ioutil"
+
+	"github.com/kardianos/service"
+	"github.com/robfig/cron"
+	"mig.ninja/mig"
+)
+
+// options mig-cron flag options
+var options cronOptions
+
+// c instance of the cron scheduling agent
+var c cron.Cron
+
+// w wait group for for waiting on commands
+var w sync.WaitGroup
+
+// logger service logger for sending output to the windows service log
+var logger service.Logger
+
+// cronOptions holds all of the individual flag and configuration options
+type cronOptions struct {
+	crontab   string
+	loaderBin string
+	// agnetKey options for updating the agent key
+	agentKey     string
+	agentKeyPath string
+	agentKeyPerm os.FileMode
+	keyPrompt    bool
+	schedule     string
+	interval     time.Duration
+	install      bool
+	foreground   bool
+	debug        bool
+	uninstall    bool
+}
+
+type program struct{}
+
+func (p *program) Start(s service.Service) error {
+	// Start should not block. Do the actual work async.
+	go start()
+	return nil
+}
+
+func (p *program) Stop(s service.Service) error {
+	// Stop should not block. Return with a few seconds.
+	stop()
+	return nil
+}
+
+func main() {
+	if err := setCronDefaults(&options); err != nil {
+		log.Fatal(err)
+	}
+
+	flag.BoolVar(&options.install, "i", options.install, "Install mig-cron as a service.")
+	flag.StringVar(&options.crontab, "c", options.crontab, "Load configuration from file.")
+	flag.DurationVar(&options.interval, "s", options.interval, "Schedule interval to run (2h, 30m, 1h).")
+	flag.StringVar(&options.loaderBin, "l", options.loaderBin, "Path to loader binary.")
+	flag.BoolVar(&options.foreground, "f", options.foreground, "Run in foreground instead of installing service.")
+	flag.BoolVar(&options.debug, "d", options.debug, "Log debug info.")
+	flag.BoolVar(&options.uninstall, "u", options.uninstall, "Uninstall mig-cron as a service.")
+	flag.StringVar(&options.agentKey, "k", options.agentKey, "Update agent API key.")
+	flag.BoolVar(&options.keyPrompt, "p", options.keyPrompt, "Prompt for inputting API key.")
+
+	flag.Parse()
+
+	//if options.foreground {
+	//	// run instead of install as a service
+	//	// start the cron scheduler in the background
+	//	start()
+	//
+	//	// catch interrupts
+	//	c := make(chan os.Signal, 1)
+	//	signal.Notify(c, os.Interrupt)
+	//	go func() {
+	//		// wait for signal
+	//		<-c
+	//		// stop the scheduler
+	//		stop()
+	//	}()
+	//
+	//	// wait for Stop
+	//	wait()
+	//	return
+	//}
+
+	svcConfig := &service.Config{
+		Name:        "mig-cron",
+		DisplayName: "mig-cron",
+		Description: "Mozilla mig cron service.",
+	}
+
+	prg := &program{}
+	s, err := service.New(prg, svcConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	logger, err = s.Logger(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if options.uninstall {
+		err = s.Uninstall()
+		if err != nil {
+			logger.Error(err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if options.agentKey != "" {
+		log.Println("mig-cron: updating loader key")
+		if err := ioutil.WriteFile(options.agentKeyPath, []byte(options.agentKey), options.agentKeyPerm); err != nil {
+			logger.Error(err)
+			os.Exit(1)
+		}
+	}
+
+	if _, err := os.Stat(options.loaderBin); os.IsNotExist(err) {
+		logger.Errorf("mig-cron: error accessing loader - %s", err.Error())
+		os.Exit(1)
+	}
+
+	if options.install {
+		err = s.Install()
+		if err != nil {
+			logger.Error(err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	err = s.Run()
+	if err != nil {
+		logger.Error(err)
+		os.Exit(1)
+	}
+	return
+}
+
+func start() {
+	options.schedule = "@every " + options.interval.String()
+	logger.Infof("mig-cron: starting")
+	logger.Infof("mig-cron: jobs - running %s %s", options.loaderBin, options.schedule)
+	c := cron.New()
+
+	if err := c.AddFunc(options.schedule, runLoader); err != nil {
+		logger.Errorf("mig-cron: invalid schedule entry %v", err)
+		panic(err)
+	}
+
+	w.Add(1)
+	c.Start()
+
+	// run loader on start
+	runLoader()
+}
+
+func stop() {
+	logger.Info("mig-cron: stopping")
+	c.Stop()
+	w.Done()
+}
+
+func wait() {
+	w.Wait()
+}
+
+func runLoader() {
+	logger.Info("mig-cron: running ", options.loaderBin)
+	out, err := exec.Command(options.loaderBin).CombinedOutput()
+	if err != nil {
+		logger.Errorf("mig-cron: error running %s %v", options.loaderBin, err)
+	}
+	if options.debug {
+		logger.Infof("mig-cron: output - %s", out)
+	}
+}
+
+func setCronDefaults(options *cronOptions) error {
+
+	bundles, err := mig.GetHostBundle()
+	if err != nil {
+		return err
+	}
+	if entry, ok := getEntry("configuration-cron", bundles); ok {
+		options.crontab = entry.Path
+	}
+	if entry, ok := getEntry("mig-loader", bundles); ok {
+		options.loaderBin = entry.Path
+	}
+	if entry, ok := getEntry("agentkey", bundles); ok {
+		options.agentKeyPath = entry.Path
+		options.agentKeyPerm = entry.Perm
+	}
+
+	options.interval = time.Duration(7200 * time.Second)
+
+	if runtime.GOOS == `windows` {
+		setCronWindowsDefaults(options)
+	}
+	return nil
+}
+
+func setCronWindowsDefaults(options *cronOptions) {
+	root := os.Getenv(mig.Env_Win_Root)
+	if root != "" && root != mig.Env_Win_Root_Defaut {
+		// setup non default paths
+		options.crontab = path.Join(root, "mig", "mig-cron.cfg")
+		options.loaderBin = path.Join(root, "mig", "mig-loader.exe")
+		options.agentKeyPath = path.Join(root, "mig", "agent.key")
+	}
+	return
+}
+
+func getEntry(name string, bundle []mig.BundleDictionaryEntry) (mig.BundleDictionaryEntry, bool) {
+	for i := 0; i < len(bundle); i++ {
+		if bundle[i].Name == name {
+			return bundle[i], true
+		}
+	}
+	return mig.BundleDictionaryEntry{}, false
+}

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -1,13 +1,26 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
+
   config.vm.provision :shell, :path => "./bootstrap.sh"
-  config.vm.network :forwarded_port, host: 51664, guest: 51664
-  config.vm.network :forwarded_port, host: 5671, guest: 5671
-  config.vm.network :forwarded_port, host: 5672, guest: 5672
-  config.vm.network :forwarded_port, host: 5432, guest: 5432
-  config.vm.network :forwarded_port, host: 12345, guest: 12345
+
+  config.vm.define "test" do |test|
+    test.vm.box="ubuntu/trusty64"
+    config.vm.network "private_network", ip: "192.168.50.110"
+
+    test.vm.network :forwarded_port, host: 51664, guest: 51664
+    test.vm.network :forwarded_port, host: 5671, guest: 5671
+    test.vm.network :forwarded_port, host: 5672, guest: 5672
+    test.vm.network :forwarded_port, host: 5432, guest: 5432
+    test.vm.network :forwarded_port, host: 12345, guest: 12345
+  end
+
+  config.vm.define "build" do |build|
+    build.vm.box = "ubuntu/xenial64"
+    build.vm.provision :shell, :path => "./bootstrap.sh", :args => "ubuntu"
+    build.vm.network "private_network", ip: "192.168.50.111"
+  end
+
   config.vm.synced_folder "../../.", "/mig", :nfs => true
-  config.vm.network "private_network", ip: "192.168.50.110"
+
   config.vm.provider :virtualbox do |p|
     p.customize ['modifyvm', :id, '--memory', '2048']
     p.customize ["modifyvm", :id, "--cpus", 2]

--- a/tools/vagrant/bootstrap.sh
+++ b/tools/vagrant/bootstrap.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -x
 
+user=${1:-$(whoami)}
+
 # Install Go
-goversion=1.7.1
+goversion=1.7.4
 echo "installing go $goversion ..."
 gofile=go${goversion}.linux-amd64.tar.gz
 gourl=https://storage.googleapis.com/golang/${gofile}
@@ -12,11 +13,11 @@ mkdir /usr/local/go
 tar -xzf /usr/local/${gofile} -C /usr/local/go --strip 1
 
 # Link the mig directory into the $GOPATH
-export GOPATH=/home/vagrant/go
+export GOPATH=/home/${user}/go
 mkdir -p $GOPATH/src/mig.ninja
-chown -R vagrant.vagrant $GOPATH
+chown -R ${user}.${user} $GOPATH
 ln -s /mig $GOPATH/src/mig.ninja/mig
-echo "export GOPATH=/home/vagrant/go" >> /home/vagrant/.profile
-echo "PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH" >> /home/vagrant/.profile
+echo "export GOPATH=/home/${user}/go" >> /home/${user}/.profile
+echo "PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH" >> /home/${user}/.profile
 
 echo "ALL DONE!!!!"

--- a/tools/windows_tools.sh
+++ b/tools/windows_tools.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+sudo apt-get install -y wixl gcc-mingw-w64
+


### PR DESCRIPTION
This PR adds a mig-cron executable to support running the loader on Windows, other platforms are supported also. The mig-cron executable uses the vanilla github.com/kardianos/service package due to issues with the package used in mig-agent.

#### Todo
- [ ] combined install for mig-cron and mig-agent 
- [ ] refactor mig-agent service install hooks (currently failing)
- [ ] integration testing to start loader and install mig-agent as a service

see https://github.com/mozilla/mig/issues/107
