### PR TITLE
Use HTTP for status socket, add agent status page

### DIFF
--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -497,6 +497,9 @@ func runAgent(runOpt runtimeOptions) (err error) {
 // startRoutines starts the goroutines that process commands, heartbeats, and look after
 // refreshing the agent environment.
 func startRoutines(ctx *Context) (err error) {
+	// Start up the HTTP stats socket
+	go initSocket(ctx)
+
 	// GoRoutine that parses and validates incoming commands
 	go func() {
 		for msg := range ctx.Channels.NewCommand {

--- a/mig-agent/context.go
+++ b/mig-agent/context.go
@@ -79,8 +79,7 @@ type Context struct {
 	OpID    float64       // ID of the current operation, used for tracking
 	Sleeper time.Duration // timer used when the agent has to sleep for a while
 	Socket  struct {
-		Bind     string
-		Listener net.Listener
+		Bind string
 	}
 	Logging mig.Logging
 }
@@ -260,23 +259,9 @@ mqdone:
 		ctx.Channels.Terminate <- sig.String()
 	}()
 
-	// try to connect the stat socket until it works
-	// this may fail if one agent is already running
+	// Set the agent stats socket bind address if set in configuration
 	if SOCKET != "" {
-		go func() {
-			for {
-				ctx.Socket.Bind = SOCKET
-				ctx, err = initSocket(ctx)
-				if err == nil {
-					ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Stat socket connected successfully on %s", ctx.Socket.Bind)}.Info()
-					goto socketdone
-				}
-				ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Failed to connect stat socket: '%v'", err)}.Err()
-				time.Sleep(60 * time.Second)
-			}
-		socketdone:
-			return
-		}()
+		ctx.Socket.Bind = SOCKET
 	}
 
 	return

--- a/mig-agent/socket.go
+++ b/mig-agent/socket.go
@@ -24,9 +24,13 @@ var statusTmpl = `<html>
 <head>
 <style>
 body {
-  background-color: linen;
-  font-family: "Lucida Console", Monaco, monospace;
-  font-size: 14px;
+  margin: 0;
+  padding: 0;
+  background: #151515;
+  color: #eaeaea;
+  font: 16px;
+  line-height: 1.5;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
 }
 div {
   padding-top: 12px;
@@ -42,7 +46,7 @@ table, td {
   font-size: 14px;
 }
 td:nth-child(2) {
-  background-color: #eeeeee;
+  background-color: #1f1f1f;
 }
 </style>
 </head>

--- a/mig-agent/socket.go
+++ b/mig-agent/socket.go
@@ -7,124 +7,56 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"io/ioutil"
 	"mig.ninja/mig"
 	"mig.ninja/mig/mig-agent/agentcontext"
-	"net"
+	"net/http"
 	"os"
-	"strings"
 	"time"
 )
 
-func initSocket(orig_ctx Context) (ctx Context, err error) {
-	ctx = orig_ctx
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("initSocket() -> %v", e)
-		}
-		ctx.Channels.Log <- mig.Log{Desc: "leaving initSocket()"}.Debug()
-	}()
-	ctx.Socket.Listener, err = net.Listen("tcp", ctx.Socket.Bind)
-	if err != nil {
-		panic(err)
-	}
-	go socketAccept(ctx)
-	return
-}
+var sockCtx *Context
 
-func socketAccept(ctx Context) {
+func initSocket(ctx *Context) {
+	sockCtx = ctx
 	for {
-
-		conn, err := ctx.Socket.Listener.Accept()
+		http.HandleFunc("/pid", socketHandlePID)
+		http.HandleFunc("/shutdown", socketHandleShutdown)
+		err := http.ListenAndServe(ctx.Socket.Bind, nil)
 		if err != nil {
-			continue
+			ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Error from stat socket: %q", err)}.Err()
 		}
-		// lock publication, serve, then exit
-		publication.Lock()
-		socketServe(conn, ctx)
-		publication.Unlock()
-		// sleep 2 seconds between accepting connections, to prevent abuses
-		time.Sleep(2 * time.Second)
+		time.Sleep(60 * time.Second)
 	}
 }
 
-// serveConn processes the request and close the connection. Connections to
-// the stat socket are single-request only.
-func socketServe(fd net.Conn, ctx Context) {
-	var (
-		resp string
-		n    int
-		err  error
-	)
-	gotdata := make(chan bool)
-	defer func() {
-		fd.Close()
-		if e := recover(); e != nil {
-			ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("socketServe() -> %v", e)}.Err()
-		}
-		ctx.Channels.Log <- mig.Log{Desc: "leaving socketServe()"}.Debug()
-	}()
-	buf := make([]byte, 8192)
-	go func() {
-		n, err = fd.Read(buf)
-		gotdata <- true
-	}()
-	select {
-	// don't wait for more than 1 second for data to come in
-	case <-time.After(1 * time.Second):
-		return
-	case <-gotdata:
-		break
+func socketCheckQueueloc(req *http.Request) error {
+	qv := req.Header.Get("AGENTID")
+	if qv == "" {
+		return fmt.Errorf("must set AGENTID header")
 	}
+	if sockCtx.Agent.UID != qv {
+		return fmt.Errorf("invalid agent id")
+	}
+	return nil
+}
+
+func socketHandlePID(w http.ResponseWriter, req *http.Request) {
+	publication.Lock()
+	defer publication.Unlock()
+	fmt.Fprintf(w, "%v", os.Getpid())
+}
+
+func socketHandleShutdown(w http.ResponseWriter, req *http.Request) {
+	publication.Lock()
+	defer publication.Unlock()
+	err := socketCheckQueueloc(req)
 	if err != nil {
+		http.Error(w, fmt.Sprintf("%v", err), http.StatusUnauthorized)
 		return
 	}
-	if n > 8190 {
-		resp = "Request too long. Max size is 8192 bytes\n"
-	} else if n < 2 {
-		resp = "Request too short. Min size is 1 byte\n"
-	} else {
-		// input data can have multiple fields, space separated
-		// the first field is always the request, the rest are optional parameters
-		fields := strings.Split(string(buf[0:n-1]), " ")
-		switch fields[0] {
-		case "pid":
-			resp = fmt.Sprintf("%d", os.Getpid())
-		case "help":
-			resp = fmt.Sprintf(`
-Welcome to the MIG agent socket. The commands are:
-pid		returns the PID of the running agent
-shutdown <id>	request agent shutdown. <id> is the agent's secret id
-`)
-		case "shutdown":
-			// to request a shutdown, the caller must provide the agent id
-			// as second argument. If the ID is valid, the string "shutdown requested"
-			// is written back to the caller, and injected into the terminate
-			// channel before returning
-			if len(fields) < 2 {
-				resp = "missing agent id, shutdown refused"
-				break
-			}
-			if fields[1] != ctx.Agent.UID {
-				resp = "invalid agent id '" + fields[1] + "', shutdown refused"
-				break
-			}
-			resp = "shutdown requested"
-		default:
-			resp = "unknown command"
-		}
-	}
-	n, err = fd.Write([]byte(resp + "\n"))
-	if err != nil {
-		panic(err)
-	}
-	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("serveConn(): %d bytes written", n)}.Debug()
-	fd.Close()
-	if resp == "shutdown requested" {
-		ctx.Channels.Terminate <- resp
-	}
+	sockCtx.Channels.Terminate <- "shutdown requested"
 }
 
 func socketQuery(bind, query string) (resp string, err error) {
@@ -133,39 +65,58 @@ func socketQuery(bind, query string) (resp string, err error) {
 			err = fmt.Errorf("socketQuery() -> %v", e)
 		}
 	}()
-	conn, err := net.Dial("tcp", bind)
-	if err != nil {
-		panic(err)
+
+	var agtid string
+	// attempt to read the agent secret id so we can append it to any orders that
+	// require it, an error is not fatal here but just means we will not be able
+	// to execute any privileged operations
+	idbuf, _ := ioutil.ReadFile(agentcontext.GetRunDir() + ".migagtid")
+	if len(idbuf) != 0 {
+		agtid = string(idbuf)
 	}
-	if query == "shutdown" {
-		// attempt to read the agent secret id and append it to the shutdown order
-		id, err := ioutil.ReadFile(agentcontext.GetRunDir() + ".migagtid")
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", "http://"+bind+"/"+query, nil)
+	if err != nil {
+		return "", err
+	}
+	switch query {
+	case "shutdown":
+		req.Header.Add("AGENTID", agtid)
+		httpresp, err := client.Do(req)
 		if err != nil {
-			panic(err)
+			return "", err
 		}
-		query = fmt.Sprintf("%s %s", query, id)
-	}
-	fmt.Fprintf(conn, query+"\n")
-	resp, err = bufio.NewReader(conn).ReadString('\n')
-	if err != nil {
-		panic(err)
-	}
-	conn.Close()
-	// remove newline
-	resp = resp[0 : len(resp)-1]
-	if len(query) > 8 && query[0:8] == "shutdown" {
+		httpresp.Body.Close()
+		// Poll the pid endpoint until a failure to wait for the agent to shutdown
 		fmt.Printf("agent shutdown requested, waiting for completion...")
+		resp = "done"
 		for {
-			// loop until socket query fails, indicating the agent is dead
 			time.Sleep(353 * time.Millisecond)
 			fmt.Printf(".")
-			conn, err = net.Dial("tcp", bind)
+			req, err = http.NewRequest("GET", "http://"+bind+"/pid", nil)
 			if err != nil {
-				resp = "done"
 				return resp, nil
 			}
-			conn.Close()
+			httpresp, err := client.Do(req)
+			if err != nil {
+				return resp, nil
+			}
+			httpresp.Body.Close()
 		}
+	case "pid":
+		httpresp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer httpresp.Body.Close()
+		respbuf, err := ioutil.ReadAll(httpresp.Body)
+		if err != nil {
+			return "", err
+		}
+		resp = string(respbuf)
+	default:
+		return "", fmt.Errorf("unknown command %q", query)
 	}
 	return
 }

--- a/mig-agent/socket.go
+++ b/mig-agent/socket.go
@@ -47,6 +47,7 @@ table, td {
 }
 td:nth-child(2) {
   background-color: #1f1f1f;
+  white-space: pre;
 }
 </style>
 </head>
@@ -151,13 +152,13 @@ func socketHandleStatus(w http.ResponseWriter, req *http.Request) {
 	tdata := templateData{Context: sockCtx}
 	tdata.Pid = os.Getpid()
 	tdata.importAgentConfig()
-	buf, err := json.Marshal(sockCtx.Agent.Env)
+	buf, err := json.MarshalIndent(sockCtx.Agent.Env, "", "    ")
 	if err != nil {
 		http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
 		return
 	}
 	tdata.Env = string(buf)
-	buf, err = json.Marshal(sockCtx.Agent.Tags)
+	buf, err = json.MarshalIndent(sockCtx.Agent.Tags, "", "    ")
 	if err != nil {
 		http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Converts existing status socket to use HTTP, updates behavior of -q to make HTTP requests, addition of a status page at / that displays various agent configuration for now.