### PR TITLE
[minor/bug] read conf and create client in mig-cmd with -i

### DIFF
--- a/client/mig/main.go
+++ b/client/mig/main.go
@@ -137,6 +137,18 @@ func main() {
 
 	// when reading the action from a file, go directly to launch
 	if os.Args[1] == "-i" {
+		conf, err = client.ReadConfiguration(migrc)
+		if err != nil {
+			panic(err)
+		}
+		conf, err = client.ReadEnvConfiguration(conf)
+		if err != nil {
+			panic(err)
+		}
+		cli, err = client.NewClient(conf, "cmd-"+mig.Version)
+		if err != nil {
+			panic(err)
+		}
 		err = fs.Parse(os.Args[1:])
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
ba34c5c moved some code in mig-cmd around so a client/configuration was
not required with -t local, but this created issues with -i as the
configuration was no longer being read. Update action file handling to
include reading configuration and creating a client.