### PR TITLE
[minor] include recent actions in agent statistics output

### DIFF
--- a/conf/mig-agent-conf.go.inc
+++ b/conf/mig-agent-conf.go.inc
@@ -94,6 +94,11 @@ var MODULETIMEOUT time.Duration = 300 * time.Second
 // if true, only the investigator's public key is verified on actions and not ACLs.
 var ONLYVERIFYPUBKEY = false
 
+// the agent keeps a summary of recent actions it has processed, which can be
+// viewed over the agents status socket. this controls the number of recent
+// actions the summary is kept for (once limit is hit, older actions are removed).
+var STATSMAXACTIONS = 15
+
 // Control modules permissions by PGP keys
 var AGENTACL = [...]string{
 	`{

--- a/conf/mig-agent.cfg.inc
+++ b/conf/mig-agent.cfg.inc
@@ -54,6 +54,11 @@
     ; if true, only the investigator's public key is verified on actions and not ACLs.
     onlyVerifyPubKey = false
 
+[stats]
+    ; number of previous actions the agent should keep a summary for. the summary can
+    ; be viewed over the agent stat socket. 0 to disable.
+    maxactions = 15
+
 [certs]
     ca  = "/path/to/ca/cert"
     cert= "/path/to/client/cert"

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -620,8 +620,12 @@ func parseCommands(ctx *Context, msg []byte) (err error) {
 	// the signer is authorized to perform this action
 	err = checkActionAuthorization(cmd.Action, ctx)
 	if err != nil {
+		ctx.Stats.importAction(cmd.Action, false)
 		panic(err)
 	}
+
+	// Note this as a successful command for statistics
+	ctx.Stats.importAction(cmd.Action, true)
 
 	// Each operation is ran separately by a module, a channel is created to receive the results from each module
 	// a goroutine is created to read from the result channel, and when all modules are done, build the response

--- a/mig-agent/configuration.go
+++ b/mig-agent/configuration.go
@@ -94,6 +94,11 @@ var MODULETIMEOUT time.Duration = 300 * time.Second
 // if true, only the investigator's public key is verified on actions and not ACLs.
 var ONLYVERIFYPUBKEY = false
 
+// the agent keeps a summary of recent actions it has processed, which can be
+// viewed over the agents status socket. this controls the number of recent
+// actions the summary is kept for (once limit is hit, older actions are removed).
+var STATSMAXACTIONS = 15
+
 // Control modules permissions by PGP keys
 var AGENTACL = [...]string{
 	`{

--- a/mig-agent/context.go
+++ b/mig-agent/context.go
@@ -82,6 +82,7 @@ type Context struct {
 		Bind string
 	}
 	Logging mig.Logging
+	Stats   agentStats
 }
 
 // Update volatile/dynamic fields in c.Agent using information stored in
@@ -151,6 +152,12 @@ func Init(foreground, upgrade bool) (ctx Context, err error) {
 		}
 	}()
 	ctx.Channels.Log <- mig.Log{Desc: "Logging routine initialized."}.Debug()
+
+	// Initialize the agent statistics tracking
+	ctx, err = initAgentStats(ctx)
+	if err != nil {
+		panic(err)
+	}
 
 	// Gather new agent context information to use as the context for this
 	// agent invocation

--- a/mig-agent/socket.go
+++ b/mig-agent/socket.go
@@ -45,7 +45,11 @@ table, td {
   border: 1px solid black;
   font-size: 14px;
 }
-td:nth-child(2) {
+.vl td:nth-child(2) {
+  background-color: #1f1f1f;
+  white-space: pre;
+}
+.hl tr:nth-of-type(2) ~ tr {
   background-color: #1f1f1f;
   white-space: pre;
 }
@@ -54,7 +58,7 @@ td:nth-child(2) {
 <body>
 <h1>mig-agent</h1>
 <div>
-<table>
+<table class="vl">
   <tr><th colspan=2>Agent status</th></tr>
   <tr><td>Agent name</td><td>{{.Context.Agent.Hostname}}</td></tr>
   <tr><td>BinPath</td><td>{{.Context.Agent.BinPath}}</td></tr>
@@ -65,7 +69,7 @@ td:nth-child(2) {
 </table>
 </div>
 <div>
-<table>
+<table class="vl">
   <tr><th colspan=2>Configuration</th></tr>
   <tr><td>Immortal</td><td>{{.Immortal}}</td></tr>
   <tr><td>Install as a service</td><td>{{.InstallService}}</td></tr>
@@ -80,6 +84,15 @@ td:nth-child(2) {
   <tr><td>Proxies</td><td>{{.Proxies}}</td></tr>
   <tr><td>Heartbeat frequency</td><td>{{.HeartBeatFreq}}</td></tr>
   <tr><td>Module timeout</td><td>{{.ModuleTimeout}}</td></tr>
+</table>
+</div>
+<div>
+<table class="hl">
+<tr><th colspan=2>Recent actions</th></tr>
+<tr><td>Time (UTC)</td><td>Name</td><td>Status</td></tr>
+{{range .Actions}}
+  <tr><td>{{.Time}}</td><td>{{.Name}}</td><td>{{.Accepted}}</tr>
+{{end}}
 </table>
 </div>
 </body>
@@ -105,6 +118,8 @@ type templateData struct {
 	Proxies          []string
 	HeartBeatFreq    time.Duration
 	ModuleTimeout    time.Duration
+
+	Actions []agentStatsAction
 }
 
 func (t *templateData) importAgentConfig() {
@@ -164,6 +179,9 @@ func socketHandleStatus(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	tdata.Tags = string(buf)
+	sockCtx.Stats.Lock()
+	defer sockCtx.Stats.Unlock()
+	tdata.Actions = sockCtx.Stats.Actions
 	t, err := template.New("status").Parse(statusTmpl)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)

--- a/mig-agent/socket.go
+++ b/mig-agent/socket.go
@@ -89,9 +89,9 @@ table, td {
 <div>
 <table class="hl">
 <tr><th colspan=2>Recent actions</th></tr>
-<tr><td>Time (UTC)</td><td>Name</td><td>Status</td></tr>
+<tr><td>Time (UTC)</td><td>Name</td><td>Modules</td><td>Status</td></tr>
 {{range .Actions}}
-  <tr><td>{{.Time}}</td><td>{{.Name}}</td><td>{{.Accepted}}</tr>
+  <tr><td>{{.Time}}</td><td>{{.Name}}</td><td>{{.Modules}}</td><td>{{.Accepted}}</tr>
 {{end}}
 </table>
 </div>

--- a/mig-agent/stats.go
+++ b/mig-agent/stats.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"mig.ninja/mig"
+	"strings"
 	"sync"
 	"time"
 )
@@ -51,12 +52,27 @@ type agentStatsAction struct {
 	Time     string
 	Name     string
 	Accepted string
+	Modules  string
 }
 
 // Add data to an agentStatsAction based on action a
 func (s *agentStatsAction) importAction(a mig.Action, accepted bool) error {
 	s.Time = time.Now().UTC().Format(time.RFC3339)
 	s.Name = a.Name
+	fl := make([]string, 0)
+	for _, x := range a.Operations {
+		found := false
+		for _, y := range fl {
+			if y == strings.ToLower(x.Module) {
+				found = true
+			}
+		}
+		if found {
+			continue
+		}
+		fl = append(fl, strings.ToLower(x.Module))
+	}
+	s.Modules = strings.Join(fl, ", ")
 	if accepted {
 		s.Accepted = "Accepted"
 	} else {

--- a/mig-agent/stats.go
+++ b/mig-agent/stats.go
@@ -19,8 +19,6 @@ import (
 	"time"
 )
 
-const maxStatActions = 15 // Keep stats for last X number of actions
-
 // Defines statistics kept by the agent
 type agentStats struct {
 	Actions []agentStatsAction
@@ -33,12 +31,15 @@ type agentStats struct {
 func (s *agentStats) importAction(a mig.Action, accepted bool) error {
 	s.Lock()
 	defer s.Unlock()
+	if STATSMAXACTIONS == 0 {
+		return nil
+	}
 	ns := agentStatsAction{}
 	err := ns.importAction(a, accepted)
 	if err != nil {
 		return err
 	}
-	if len(s.Actions) == maxStatActions {
+	if len(s.Actions) == STATSMAXACTIONS {
 		s.Actions = s.Actions[1:]
 	}
 	s.Actions = append(s.Actions, ns)

--- a/mig-agent/stats.go
+++ b/mig-agent/stats.go
@@ -55,7 +55,7 @@ type agentStatsAction struct {
 
 // Add data to an agentStatsAction based on action a
 func (s *agentStatsAction) importAction(a mig.Action, accepted bool) error {
-	s.Time = time.Now().UTC().Format("Jan 2 15:04:05 2006")
+	s.Time = time.Now().UTC().Format(time.RFC3339)
 	s.Name = a.Name
 	if accepted {
 		s.Accepted = "Accepted"

--- a/mig-agent/stats.go
+++ b/mig-agent/stats.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package main
+
+// Contains functions related to agent statistics. Currently this data is not
+// persistent and will be lost of the agent process is restarted, this could be
+// adapted to make use of local storage as needed.
+//
+// The information here can be presented by querying the agent on its status
+// socket.
+
+import (
+	"mig.ninja/mig"
+	"sync"
+	"time"
+)
+
+const maxStatActions = 15 // Keep stats for last X number of actions
+
+// Defines statistics kept by the agent
+type agentStats struct {
+	Actions []agentStatsAction
+	sync.Mutex
+}
+
+// Import information about an incoming action into agent statistics. If
+// accepted is true the action was executed by the agent, if false it means
+// the action was rejected (e.g., due to lack of signatures).
+func (s *agentStats) importAction(a mig.Action, accepted bool) error {
+	s.Lock()
+	defer s.Unlock()
+	ns := agentStatsAction{}
+	err := ns.importAction(a, accepted)
+	if err != nil {
+		return err
+	}
+	if len(s.Actions) == maxStatActions {
+		s.Actions = s.Actions[1:]
+	}
+	s.Actions = append(s.Actions, ns)
+	return nil
+}
+
+// Stats we keep for an action processed by the agent
+type agentStatsAction struct {
+	Time     string
+	Name     string
+	Accepted string
+}
+
+// Add data to an agentStatsAction based on action a
+func (s *agentStatsAction) importAction(a mig.Action, accepted bool) error {
+	s.Time = time.Now().UTC().Format("Jan 2 15:04:05 2006")
+	s.Name = a.Name
+	if accepted {
+		s.Accepted = "Accepted"
+	} else {
+		s.Accepted = "Rejected"
+	}
+	return nil
+}
+
+// Initialize agent statistics
+func initAgentStats(ctx Context) (newctx Context, err error) {
+	newctx = ctx
+	ctx.Stats = agentStats{}
+	ctx.Channels.Log <- mig.Log{Desc: "Agent statistics management initialized"}.Info()
+	return
+}

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -331,6 +331,7 @@ var MODULETIMEOUT time.Duration = 300 * time.Second
 var ONLYVERIFYPUBKEY = false
 var SPAWNPERSISTENT bool = true
 var MODULECONFIGDIR = "/etc/mig"
+var STATSMAXACTIONS = 15
 var AGENTACL = [...]string{
 \`{
     "default": {


### PR DESCRIPTION
Agent tracks some basic stats on the last 15 actions it has received and provides details on these via the status socket. This includes if the action was processed or not.

Currently this is limited to in-memory stats which would be lost on restart, but the intent is it can be adapted to make use of local storage for persistence if needed.