### PR TITLE
[minor/bug] resolve write to closed chan Terminate panic on shutdown

### DIFF
--- a/mig-agent/context.go
+++ b/mig-agent/context.go
@@ -465,14 +465,14 @@ func initMQ(orig_ctx Context, try_proxy bool, proxy string) (ctx Context, err er
 }
 
 func Destroy(ctx Context) (err error) {
-	close(ctx.Channels.Terminate)
 	close(ctx.Channels.NewCommand)
 	close(ctx.Channels.RunAgentCommand)
 	close(ctx.Channels.RunExternalCommand)
 	close(ctx.Channels.Results)
+	ctx.MQ.conn.Close()
 	// give one second for the goroutines to close
 	time.Sleep(1 * time.Second)
-	ctx.MQ.conn.Close()
+	close(ctx.Channels.Terminate)
 	return
 }
 


### PR DESCRIPTION
When the agent shuts down (e.g. due to a signal, etc) a message is sent
to the Terminate channel, which results eventually in the agent Context
being destroyed.

The terminate channel was being closed before the AMQP connection was
being shut down. This was causing a panic as the getCommands function
also writes to the terminate channel to indicate relay collection is
failing.

Move close of Terminate later in destroy and after we shut down the AMQP
connection so prevent the write on the closed Terminate channel in
getCommands.