### PR TITLE
[minor/bug] register endpoints on status socket once

### DIFF
--- a/mig-agent/socket.go
+++ b/mig-agent/socket.go
@@ -143,10 +143,10 @@ func (t *templateData) importAgentConfig() {
 
 func initSocket(ctx *Context) {
 	sockCtx = ctx
+	http.HandleFunc("/pid", socketHandlePID)
+	http.HandleFunc("/shutdown", socketHandleShutdown)
+	http.HandleFunc("/", socketHandleStatus)
 	for {
-		http.HandleFunc("/pid", socketHandlePID)
-		http.HandleFunc("/shutdown", socketHandleShutdown)
-		http.HandleFunc("/", socketHandleStatus)
 		err := http.ListenAndServe(ctx.Socket.Bind, nil)
 		if err != nil {
 			ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Error from stat socket: %q", err)}.Err()


### PR DESCRIPTION
If the agent fails to bind the status socket, it will wait and retry
again. As part of this retry, it was also binding endpoints to register
them in the http package for the status socket which would result in a
panic.

Changes behavior so endpoints are only registered once.