### PR TITLE
Support API key authentication for mig API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1134,7 +1134,7 @@ func (cli Client) PostInvestigatorStatus(iid float64, newstatus string) (err err
 	return
 }
 
-// PostInvestigatorAPIKey is used to either enable or disable API key based access
+// PostInvestigatorAPIKeyStatus is used to either enable or disable API key based access
 // to the MIG API for an investigator. API key based access to the API can be used in
 // place of X-PGPAUTHORIZATION API authentication.
 //
@@ -1142,7 +1142,7 @@ func (cli Client) PostInvestigatorStatus(iid float64, newstatus string) (err err
 // assigned key. newstatus should be set to either 'active' or 'disabled'. If a key already
 // exists for an investigator, calling this with a status of 'active' will cause the existing
 // key to be replaced.
-func (cli Client) PostInvestigatorAPIKey(iid float64, newstatus string) (inv mig.Investigator, err error) {
+func (cli Client) PostInvestigatorAPIKeyStatus(iid float64, newstatus string) (inv mig.Investigator, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("PostInvestigatorAPIKey() -> %v", e)

--- a/client/client.go
+++ b/client/client.go
@@ -57,9 +57,10 @@ type ApiConf struct {
 	SkipVerifyCert bool
 }
 type GpgConf struct {
-	Home      string
-	KeyID     string
-	Keyserver string
+	Home          string // Path to GPG keyrings
+	KeyID         string // GPG key ID to use for X-PGPAUTHORIZATION and action signing
+	Keyserver     string // Key server to fetch keys from if needed in mig-console
+	UseAPIKeyAuth string // Prefer X-MIGAPIKEY authentication for API access, set to API key
 }
 
 type TargetConf struct {
@@ -297,16 +298,22 @@ func (cli Client) Do(r *http.Request) (resp *http.Response, err error) {
 		}
 	}()
 	r.Header.Set("User-Agent", "MIG Client "+cli.Version)
-	if cli.Token == "" {
-		cli.Token, err = cli.MakeSignedToken()
-		if err != nil {
-			panic(err)
+	// If API key authentication has been configured, use that rather than
+	// X-PGPAUTHORIZATION authentication for the API
+	if cli.Conf.GPG.UseAPIKeyAuth != "" {
+		r.Header.Set("X-MIGAPIKEY", cli.Conf.GPG.UseAPIKeyAuth)
+	} else {
+		if cli.Token == "" {
+			cli.Token, err = cli.MakeSignedToken()
+			if err != nil {
+				panic(err)
+			}
 		}
-	}
-	r.Header.Set("X-PGPAUTHORIZATION", cli.Token)
-	if cli.debug {
-		fmt.Printf("debug: %s %s %s\ndebug: User-Agent: %s\ndebug: X-PGPAUTHORIZATION: %s\n",
-			r.Method, r.URL.String(), r.Proto, r.UserAgent(), r.Header.Get("X-PGPAUTHORIZATION"))
+		r.Header.Set("X-PGPAUTHORIZATION", cli.Token)
+		if cli.debug {
+			fmt.Printf("debug: %s %s %s\ndebug: User-Agent: %s\ndebug: X-PGPAUTHORIZATION: %s\n",
+				r.Method, r.URL.String(), r.Proto, r.UserAgent(), r.Header.Get("X-PGPAUTHORIZATION"))
+		}
 	}
 	// execute the request
 	resp, err = cli.API.Do(r)
@@ -319,7 +326,7 @@ func (cli Client) Do(r *http.Request) (resp *http.Response, err error) {
 	}
 	// if the request failed because of an auth issue, it may be that the auth token has expired.
 	// try the request again with a fresh token
-	if resp.StatusCode == http.StatusUnauthorized {
+	if resp.StatusCode == http.StatusUnauthorized && cli.Conf.GPG.UseAPIKeyAuth == "" {
 		// Make sure we read the entire response body from the previous request before we close it
 		// to avoid connection cancellation issues and a panic in API.Do()
 		_, err = ioutil.ReadAll(resp.Body)
@@ -977,7 +984,8 @@ func (cli Client) GetInvestigator(iid float64) (inv mig.Investigator, err error)
 	return
 }
 
-// PostInvestigator creates an Investigator and returns the reflected investigator
+// PostInvestigator creates an Investigator and returns the reflected investigator. If pubkey
+// is zero-length, the investigator will be created without a PGP public key.
 func (cli Client) PostInvestigator(name string, pubkey []byte, pset mig.InvestigatorPerms) (inv mig.Investigator, err error) {
 	defer func() {
 		if e := recover(); e != nil {
@@ -1000,14 +1008,16 @@ func (cli Client) PostInvestigator(name string, pubkey []byte, pset mig.Investig
 	if err != nil {
 		panic(err)
 	}
-	// set the publickey form value
-	part, err := writer.CreateFormFile("publickey", fmt.Sprintf("%s.asc", name))
-	if err != nil {
-		panic(err)
-	}
-	_, err = io.Copy(part, bytes.NewReader(pubkey))
-	if err != nil {
-		panic(err)
+	if len(pubkey) > 0 {
+		// set the publickey form value
+		part, err := writer.CreateFormFile("publickey", fmt.Sprintf("%s.asc", name))
+		if err != nil {
+			panic(err)
+		}
+		_, err = io.Copy(part, bytes.NewReader(pubkey))
+		if err != nil {
+			panic(err)
+		}
 	}
 	// must close the writer to write trailing boundary
 	err = writer.Close()
@@ -1119,6 +1129,54 @@ func (cli Client) PostInvestigatorStatus(iid float64, newstatus string) (err err
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("error: HTTP %d. status update failed with error '%v' (code %s)",
 			resp.StatusCode, resource.Collection.Error.Message, resource.Collection.Error.Code)
+		panic(err)
+	}
+	return
+}
+
+// PostInvestigatorAPIKey is used to either enable or disable API key based access
+// to the MIG API for an investigator. API key based access to the API can be used in
+// place of X-PGPAUTHORIZATION API authentication.
+//
+// If an API key is being set, the returned investigator APIKey value will contain the
+// assigned key. newstatus should be set to either 'active' or 'disabled'. If a key already
+// exists for an investigator, calling this with a status of 'active' will cause the existing
+// key to be replaced.
+func (cli Client) PostInvestigatorAPIKey(iid float64, newstatus string) (inv mig.Investigator, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("PostInvestigatorAPIKey() -> %v", e)
+		}
+	}()
+	data := url.Values{"id": {fmt.Sprintf("%.0f", iid)}, "apikey": {newstatus}}
+	r, err := http.NewRequest("POST", cli.Conf.API.URL+"investigator/update/", strings.NewReader(data.Encode()))
+	if err != nil {
+		panic(err)
+	}
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := cli.Do(r)
+	if err != nil {
+		panic(err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	var resource *cljs.Resource
+	if len(body) > 1 {
+		err = json.Unmarshal(body, &resource)
+		if err != nil {
+			panic(err)
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("error: HTTP %d. apikey update failed with error '%v' (code %s)",
+			resp.StatusCode, resource.Collection.Error.Message, resource.Collection.Error.Code)
+		panic(err)
+	}
+	inv, err = ValueToInvestigator(resource.Collection.Items[0].Data[0].Value)
+	if err != nil {
 		panic(err)
 	}
 	return

--- a/client/mig-console/investigator.go
+++ b/client/mig-console/investigator.go
@@ -84,7 +84,7 @@ func investigatorReader(input string, cli client.Client) (err error) {
 					break
 				}
 			}
-			retinv, err := cli.PostInvestigatorAPIKey(iid, newstatus)
+			retinv, err := cli.PostInvestigatorAPIKeyStatus(iid, newstatus)
 			if err != nil {
 				panic(err)
 			}

--- a/client/mig-console/investigator.go
+++ b/client/mig-console/investigator.go
@@ -46,7 +46,7 @@ func investigatorReader(input string, cli client.Client) (err error) {
 	prompt := fmt.Sprintf("\x1b[35;1minv %.0f>\x1b[0m ", iid)
 	for {
 		// completion, for convenience also add permission categories here
-		var symbols = []string{"details", "exit", "help", "pubkey", "r", "lastactions",
+		var symbols = []string{"apikey", "details", "exit", "help", "pubkey", "r", "lastactions",
 			"setperms", "setstatus", "PermManifest", "PermLoader", "PermAdmin"}
 		readline.Completer = func(query, ctx string) []string {
 			var res []string
@@ -68,21 +68,65 @@ func investigatorReader(input string, cli client.Client) (err error) {
 		}
 		orders := strings.Split(strings.TrimSpace(input), " ")
 		switch orders[0] {
+		case "apikey":
+			if len(orders) != 2 {
+				fmt.Println("error: must be 'apikey <status>'. try 'help'")
+				break
+			}
+			newstatus := orders[1]
+			if newstatus == "active" && inv.APIKey != "" {
+				fmt.Println("investigator already has an assigned API key")
+				input, err := readline.String("generate new key? (y/n)> ")
+				if err != nil {
+					panic(err)
+				}
+				if input != "y" {
+					break
+				}
+			}
+			retinv, err := cli.PostInvestigatorAPIKey(iid, newstatus)
+			if err != nil {
+				panic(err)
+			}
+			if retinv.APIKey != "" {
+				fmt.Printf("API key for investigator set to %q\n", retinv.APIKey)
+			}
+			inv, err = cli.GetInvestigator(iid)
+			if err != nil {
+				panic(err)
+			}
 		case "details":
+			var (
+				displaykey string
+				apikeyset  bool
+			)
+			displaykey = inv.PGPFingerprint
+			if displaykey == "" {
+				displaykey = "No PGP key assigned"
+			}
+			if inv.APIKey != "" {
+				// The API will set the APIKey value for the investigator to "set"
+				// if a key is associated with the user, otherwise it is ""
+				apikeyset = true
+			} else {
+				apikeyset = false
+			}
 			fmt.Printf("Investigator ID %.0f\n"+
 				"name           %s\n"+
 				"status         %s\n"+
 				"permissions    %v\n"+
 				"key id         %s\n"+
 				"created        %s\n"+
-				"modified       %s\n",
+				"modified       %s\n"+
+				"api key set    %v\n",
 				inv.ID, inv.Name, inv.Status, inv.Permissions.ToDescriptive(),
-				inv.PGPFingerprint, inv.CreatedAt, inv.LastModified)
+				displaykey, inv.CreatedAt, inv.LastModified, apikeyset)
 		case "exit":
 			fmt.Printf("exit\n")
 			goto exit
 		case "help":
 			fmt.Printf(`The following orders are available:
+apikey <status>           enable or disable X-MIGAPIKEY access for investigator (can be 'active' or 'disabled')
 details			  print the details of the investigator
 exit			  exit this mode
 help			  show this help
@@ -213,8 +257,8 @@ func printInvestigatorLastActions(iid float64, limit int, cli client.Client) (er
 	return
 }
 
-// investigatorCreator prompt the user for a name and the path to an armored
-// public key and calls the API to create a new investigator
+// investigatorCreator prompts the user for various attributes and calls the
+// API to create a new investigator.
 func investigatorCreator(cli client.Client) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
@@ -225,8 +269,8 @@ func investigatorCreator(cli client.Client) (err error) {
 		name   string
 		pubkey []byte
 	)
-	fmt.Println("Entering investigator creation mode. Please provide the full name\n" +
-		"additional permissions if desired, and the public key of the new investigator.")
+	fmt.Println("Entering investigator creation mode.\n\nPlease provide the full name" +
+		" for the new investigator.")
 	name, err = readline.String("name> ")
 	if err != nil {
 		panic(err)
@@ -234,13 +278,16 @@ func investigatorCreator(cli client.Client) (err error) {
 	if len(name) < 3 {
 		panic("input name too short")
 	}
-	fmt.Printf("Name: '%s'\n", name)
+	fmt.Printf("Name: %q\n\n", name)
+
 	pset := mig.InvestigatorPerms{}
 	pset.DefaultSet()
-	fmt.Println("With no additional permissions, the investigator will be permitted\n" +
-		"access to run investigations. Answer yes to any of the following to add\n" +
-		"additional permissions to the investigator.\n\nIf this is the first " +
-		"investigator being added, you should make this\ninvestigator an admin.")
+	fmt.Println("Permissions restrict an investigator to certain functions within the API.\n" +
+		"By default, the investigator is limited to investigation related functions such as\n" +
+		"creating investigations or viewing results. Additional permissions can be assigned\n" +
+		"which provide increased access for the investigator such as the ability to create\n" +
+		"new investigators.\n\n" +
+		"Enter yes to any of the following to add increased privileges.")
 	respv, err := readline.String("Allow investigator to manage users (admin)? (yes/no)> ")
 	if err != nil {
 		panic(err)
@@ -273,40 +320,57 @@ func investigatorCreator(cli client.Client) (err error) {
 	}
 	switch strings.ToLower(respv) {
 	case "yes":
-		fmt.Println("Investigator will have manifest management permissions")
+		fmt.Println("Investigator will have manifest management permissions\n")
 		pset.ManifestSet()
 	case "no":
-		fmt.Println("Investigator will not have manifest management permissions")
+		fmt.Println("Investigator will not have manifest management permissions\n")
 	default:
 		panic("must specify yes or no")
 	}
-	fmt.Println("Please provide a public key. You can either provide a local path to the\n" +
-		"armored public key file, or a full length PGP fingerprint.\n" +
-		"example:\npubkey> 0x716CFA6BA8EBB21E860AE231645090E64367737B")
-	input, err := readline.String("pubkey> ")
+
+	fmt.Println("Generally you will want a PGP public key associated with the investigator. This provides\n" +
+		"the investigator the ability to query agents. It is also possible to skip adding a PGP key,\n" +
+		"in which case the investigator will be limited to interactions with the API if API key based\n" +
+		"authentication is enabled for the investigator.\n\n" +
+		"Only answer no here if you have an advanced use-case and are familiar with how authentication\n" +
+		"in MIG works.\n")
+	respv, err = readline.String("Add a public key for the investigator? (yes/no)> ")
 	if err != nil {
 		panic(err)
 	}
-	re := regexp.MustCompile(`^0x[ABCDEF0-9]{8,64}$`)
-	if re.MatchString(input) {
-		var keyserver string
-		if cli.Conf.GPG.Keyserver == "" {
-			keyserver = "http://gpg.mozilla.org"
-		}
-		fmt.Println("retrieving public key from", keyserver)
-		pubkey, err = pgp.GetArmoredKeyFromKeyServer(input, keyserver)
+	if strings.ToLower(respv) == "yes" {
+		fmt.Println("Please provide a public key. You can either provide a local path to the\n" +
+			"armored public key file, or a full length PGP fingerprint.\n" +
+			"example:\npubkey> 0x716CFA6BA8EBB21E860AE231645090E64367737B")
+		input, err := readline.String("pubkey> ")
 		if err != nil {
 			panic(err)
 		}
+		re := regexp.MustCompile(`^0x[ABCDEF0-9]{8,64}$`)
+		if re.MatchString(input) {
+			var keyserver string
+			if cli.Conf.GPG.Keyserver == "" {
+				keyserver = "http://gpg.mozilla.org"
+			}
+			fmt.Println("retrieving public key from", keyserver)
+			pubkey, err = pgp.GetArmoredKeyFromKeyServer(input, keyserver)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			fmt.Println("retrieving public key from", input)
+			pubkey, err = ioutil.ReadFile(input)
+			if err != nil {
+				panic(err)
+			}
+		}
+		fmt.Printf("%s\n", pubkey)
+	} else if strings.ToLower(respv) == "no" {
+		fmt.Print("\n")
 	} else {
-		fmt.Println("retrieving public key from", input)
-		pubkey, err = ioutil.ReadFile(input)
-		if err != nil {
-			panic(err)
-		}
+		panic("must specify yes or no")
 	}
-	fmt.Printf("%s\n", pubkey)
-	input, err = readline.String("create investigator? (y/n)> ")
+	input, err := readline.String("create investigator? (y/n)> ")
 	if err != nil {
 		panic(err)
 	}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -103,7 +103,9 @@ CREATE TABLE investigators (
     status          character varying(255) NOT NULL,
     createdat       timestamp with time zone NOT NULL,
     lastmodified    timestamp with time zone NOT NULL,
-    permissions     bigint NOT NULL DEFAULT 0
+    permissions     bigint NOT NULL DEFAULT 0,
+    apikey          bytea,
+    apisalt         bytea
 );
 ALTER TABLE public.investigators OWNER TO migadmin;
 ALTER TABLE ONLY investigators
@@ -206,11 +208,11 @@ GRANT USAGE ON SEQUENCE investigators_id_seq TO migscheduler;
 
 -- API has limited permissions, and cannot list scheduler private keys in the investigators table, but can update their statuses
 GRANT SELECT ON actions, agents, agents_stats, agtmodreq, commands, invagtmodperm, loaders, manifests, manifestsig, modules, signatures TO migapi;
-GRANT SELECT (id, name, pgpfingerprint, publickey, status, createdat, lastmodified, permissions) ON investigators TO migapi;
+GRANT SELECT (id, name, pgpfingerprint, publickey, status, createdat, lastmodified, permissions, apikey, apisalt) ON investigators TO migapi;
 GRANT INSERT ON actions, signatures, manifests, manifestsig, loaders TO migapi;
 GRANT DELETE ON manifestsig TO migapi;
 GRANT INSERT (name, pgpfingerprint, publickey, status, createdat, lastmodified, permissions) ON investigators TO migapi;
-GRANT UPDATE (permissions, status, lastmodified) ON investigators TO migapi;
+GRANT UPDATE (permissions, status, lastmodified, apikey, apisalt) ON investigators TO migapi;
 GRANT UPDATE (name, env, tags, loaderkey, salt, lastseen, enabled, expectenv, queueloc) ON loaders TO migapi;
 GRANT UPDATE (status) ON manifests TO migapi;
 GRANT USAGE ON SEQUENCE investigators_id_seq TO migapi;

--- a/database/searches.go
+++ b/database/searches.go
@@ -698,9 +698,10 @@ func (db *DB) SearchInvestigators(p search.Parameters) (investigators []mig.Inve
 	if err != nil {
 		return
 	}
-	columns := `investigators.id, investigators.name, investigators.pgpfingerprint,
-		investigators.status, investigators.createdat, investigators.lastmodified,
-		investigators.permissions`
+	columns := `investigators.id, investigators.name,
+		COALESCE(investigators.pgpfingerprint, ''),
+		investigators.status, investigators.createdat,
+		investigators.lastmodified, investigators.permissions`
 	join := ""
 	where := ""
 	vals := []interface{}{}

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -104,7 +104,7 @@ GET /api/v1/dashboard
 * Description: returns a status dashboard with counters of active and idle
   agents, and a list of the last 10 actions ran.
 * Parameters: none
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -287,7 +287,7 @@ GET /api/v1/dashboard
 GET /api/v1/action
 ~~~~~~~~~~~~~~~~~~
 * Description: retrieve an action by its ID. Include links to related commands.
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Parameters:
 	- `actionid`: a uint64 that identifies an action by its ID
 * Response Code: 200 OK
@@ -414,7 +414,7 @@ GET /api/v1/action
 POST /api/v1/action/create/
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Description: send a signed action to the API for submission to the scheduler.
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Parameters: (POST body)
 	- `action`: a signed action in JSON format
 * Response Code: 202 Accepted
@@ -423,7 +423,7 @@ POST /api/v1/action/create/
 GET /api/v1/agent
 ~~~~~~~~~~~~~~~~~
 * Description: retrieve an agent by its ID
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Parameters:
 	- `agentid`: a uint64 that identifies an agent by its ID
 * Response Code: 200 OK
@@ -478,7 +478,7 @@ GET /api/v1/agent
 GET /api/v1/command
 ~~~~~~~~~~~~~~~~~~~
 * Description: retrieve a command by its ID. Include link to related action.
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Parameters:
 	- `commandid`: a uint64 that identifies a command by its ID
 * Response Code: 200 OK
@@ -707,7 +707,7 @@ GET /api/v1/investigator
 ~~~~~~~~~~~~~~~~~~~~~~~~
 * Description: retrieve an investigator by its ID. Include link to the
   investigator's action history.
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Parameters:
 	- `investigatorid`: a uint64 that identifies a command by its ID
 * Response Code: 200 OK
@@ -753,7 +753,7 @@ GET /api/v1/investigator
 POST /api/v1/investigator/create/
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Description: create a new investigator in the database
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Parameters: (POST body)
         - `name`: string that represents the full name
         - `publickey`: armored GPG public key
@@ -770,7 +770,7 @@ POST /api/v1/investigator/create/
 POST /api/v1/investigator/update/
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Description: update an existing investigator in the database
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Parameters: (POST body)
         - `id`: investigator id, to identify the target investigator
         - `status`: new status of the investigator, to be updated
@@ -788,7 +788,7 @@ One of either ``status`` or ``permissions`` must be passed to this API endpoint.
 GET /api/v1/search
 ~~~~~~~~~~~~~~~~~~
 * Description: search for actions, commands, agents or investigators.
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 * Parameters:
@@ -906,7 +906,7 @@ GET /api/v1/loader
 * Description: Returns the details of a particular loader instance
 * Parameters:
 	- `loaderid`: ID of loader instance to return
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -945,7 +945,7 @@ POST /api/v1/loader/status/
 * Parameters: (POST body)
         - `loaderid`: ID of loader instance to modify
         - `status`: New status, "enabled" or "disabled"
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -955,7 +955,7 @@ POST /api/v1/loader/key/
 * Parameters: (POST body)
         - `loaderid`: ID of loader instance to modify
         - `loaderkey`: New key for loader instance
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -964,7 +964,7 @@ POST /api/v1/loader/new/
 * Description: Create a new loader instance
 * Parameters: (POST body)
 	- `loader`: JSON marshaled mig.LoaderEntry data
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 201 Created
 * Response: Collection+JSON
 
@@ -973,7 +973,7 @@ GET /api/v1/manifest/
 * Description: Return details of a given manifest
 * Parameters:
 	- `manifestid`: ID of manifest to return
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -1013,7 +1013,7 @@ POST /api/v1/manifest/sign/
 * Parameters: (POST body)
         - `manifestid`: ID of manifest to sign
         - `signature`: The signature to add
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -1023,7 +1023,7 @@ POST /api/v1/manifest/status/
 * Parameters: (POST body)
         - `manifestid`: ID of manifest to change
         - `status`: Status for manifest, "staged" or "disabled"
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -1032,7 +1032,7 @@ POST /api/v1/manifest/new/
 * Description: Create a new manifest
 * Parameters: (POST body)
 	- `manifest`: JSON marshaled mig.ManifestRecord data
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 201 Created
 * Response: Collection+JSON
 
@@ -1041,7 +1041,7 @@ GET /api/v1/manifest/loaders/
 * Description: Return known loader instances this manifest will match
 * Parameters:
 	- `manifestid`: ID of manifest to return loaders for
-* Authentication: X-PGPAUTHORIZATION
+* Authentication: X-PGPAUTHORIZATION or X-MIGAPIKEY
 * Response Code: 200 OK
 * Response: Collection+JSON
 
@@ -1446,6 +1446,21 @@ Generating a token in Python
 			headers={'X-PGPAUTHORIZATION': token})
 		print token
 		print r.text
+
+Authentication with X-MIGAPIKEY
+-------------------------------
+X-PGPAUTHORIZATION is the preferred way clients authenticate with the MIG API. In addition
+to that method, clients can also authenticate using the X-MIGAPIKEY header. This is a standard
+API key header that simplifies API access in cases where using PGP to generate an X-PGPAUTHORIZATION
+header may not be ideal.
+
+Note that to create investigations, PGP is still required in order to sign actions, so clients
+which rely solely on X-MIGAPIKEY capability will not be able to interrogate agents. However, in
+cases where integration is desired with the API to perform basic API related functions such as
+adding users, managing loaders, etc, this integration can be achieved using API keys without
+needing to utilize PGP signing of the authorization header.
+
+Investigators can be assigned an API key using mig-console.
 
 Authentication with X-LOADERKEY
 -------------------------------

--- a/doc/console.rst
+++ b/doc/console.rst
@@ -450,6 +450,18 @@ By default unless specific investigators will be created with no
 additional permissions. Answering yes to the permission related
 questions grant the investigator additional access to API functionality.
 
+Providing a PGP public key for the investigator is optional. There may
+be scenarios you want to create an investigator without a public key. For
+example, if you want to create an investigator to be used solely for API
+access and make use of X-MIGAPIKEY authentication instead of requiring
+X-PGPAUTHORIZATION. If you do not assign a PGP key to the investigator
+at this stage, you will not be able to later. An example of a scenario
+where you may not want to add a PGP key, might be one where you want to
+integrate an external application with the capability to manage part of
+MIG. In this case, you could create an investigator without the PGP key, and
+later assign an API key to the investigator, granting this investigator
+access to the API using X-MIGAPIKEY authentication.
+
 You can either provide a local path to the public key file on disk,
 on provide a fingerprint in the format "0x<40 char sha1 hash>". When
 a fingerprint is provided, the console will attempt to retrieve the

--- a/investigator.go
+++ b/investigator.go
@@ -20,6 +20,7 @@ type Investigator struct {
 	Status         string    `json:"status"`
 	CreatedAt      time.Time `json:"createdat"`
 	LastModified   time.Time `json:"lastmodified"`
+	APIKey         string    `json:"apikey,omitempty"`
 
 	Permissions InvestigatorPerms `json:"permissions"`
 }
@@ -371,3 +372,12 @@ const (
 	StatusActiveInvestigator   string = "active"
 	StatusDisabledInvestigator string = "disabled"
 )
+
+// InvestigatorAPIAuthHelper is a small struct used to pass information between
+// the database and the API, and is used primarily for authorizing requests using
+// API keys.
+type InvestigatorAPIAuthHelper struct {
+	ID     float64 // Investigator ID
+	APIKey []byte  // Key hash
+	Salt   []byte  // Key salt
+}

--- a/loader.go
+++ b/loader.go
@@ -9,7 +9,6 @@ package mig /* import "mig.ninja/mig" */
 import (
 	"errors"
 	"fmt"
-	mrand "math/rand"
 	"regexp"
 	"time"
 )
@@ -52,25 +51,12 @@ func (lad *LoaderAuthDetails) Validate() error {
 
 // Generate a new loader prefix value
 func GenerateLoaderPrefix() string {
-	return RandLoaderKeyString(LoaderPrefixLength)
+	return RandAPIKeyString(LoaderPrefixLength)
 }
 
 // Generate a new loader key value
 func GenerateLoaderKey() string {
-	return RandLoaderKeyString(LoaderKeyLength)
-}
-
-// RandLoaderKeyString is used for prefix and key generation, and just
-// returns a random string consisting of alphanumeric characters of
-// length characters long
-func RandLoaderKeyString(length int) string {
-	ret := make([]byte, length)
-	lset := []byte("abcdefghijklmnopqrstuvwxyzABCDEFCHIJKLMNOPQRSTUVWXYZ0123456789")
-	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < len(ret); i++ {
-		ret[i] = lset[r.Int()%len(lset)]
-	}
-	return string(ret[:len(ret)])
+	return RandAPIKeyString(LoaderKeyLength)
 }
 
 // Various constants related to properties of the loader keys

--- a/mig-api/manifest_endpoints.go
+++ b/mig-api/manifest_endpoints.go
@@ -591,7 +591,7 @@ func keyLoader(respWriter http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		panic(err)
 	}
-	hashkey, salt, err := hashLoaderKey(lkey, nil)
+	hashkey, salt, err := hashAPIKey(lkey, nil, mig.LoaderHashedKeyLength, mig.LoaderSaltLength)
 	if err != nil {
 		panic(err)
 	}
@@ -638,7 +638,7 @@ func newLoader(respWriter http.ResponseWriter, request *http.Request) {
 		panic(err)
 	}
 	// Hash the loader key to provide it to LoaderAdd
-	hkey, salt, err := hashLoaderKey(le.Key, nil)
+	hkey, salt, err := hashAPIKey(le.Key, nil, mig.LoaderHashedKeyLength, mig.LoaderSaltLength)
 	if err != nil {
 		panic(err)
 	}

--- a/mig-api/pgp.go
+++ b/mig-api/pgp.go
@@ -25,7 +25,7 @@ func makeKeyring() (keyring io.ReadSeeker, err error) {
 		}
 		ctx.Channels.Log <- mig.Log{Desc: "leaving makeKeyring()"}.Debug()
 	}()
-	keys, err := ctx.DB.ActiveInvestigatorsKeys()
+	keys, err := ctx.DB.ActiveInvestigatorsPubKeys()
 	if err != nil {
 		panic(err)
 	}

--- a/mig-scheduler/pgp.go
+++ b/mig-scheduler/pgp.go
@@ -24,7 +24,7 @@ func makePubring(ctx Context) (pubring io.ReadSeeker, err error) {
 		}
 		ctx.Channels.Log <- mig.Log{Desc: "leaving makePubring()"}.Debug()
 	}()
-	keys, err := ctx.DB.ActiveInvestigatorsKeys()
+	keys, err := ctx.DB.ActiveInvestigatorsPubKeys()
 	if err != nil {
 		panic(err)
 	}

--- a/misc.go
+++ b/misc.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Aaron Meihm ameihm@mozilla.com [:alm]
+
+package mig /* import "mig.ninja/mig" */
+
+// Misc support functions used in various places within MIG
+
+import (
+	mrand "math/rand"
+	"time"
+)
+
+// RandAPIKeyString is used for prefix and key generation, and just
+// returns a random string consisting of alphanumeric characters of
+// length characters long
+func RandAPIKeyString(length int) string {
+	ret := make([]byte, length)
+	lset := []byte("abcdefghijklmnopqrstuvwxyzABCDEFCHIJKLMNOPQRSTUVWXYZ0123456789")
+	r := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < len(ret); i++ {
+		ret[i] = lset[r.Int()%len(lset)]
+	}
+	return string(ret[:len(ret)])
+}

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -295,7 +295,7 @@ gpg --no-default-keyring --keyring ~/.mig/pubring.gpg \
     --secret-keyring ~/.mig/secring.gpg \
     --export -a $(whoami)@$(hostname) \
     > ~/.mig/$(whoami)-pubkey.asc || fail
-echo -e "create investigator\n$(whoami)\nyes\nyes\nyes\n$HOME/.mig/$(whoami)-pubkey.asc\ny\n" | \
+echo -e "create investigator\n$(whoami)\nyes\nyes\nyes\nyes\n$HOME/.mig/$(whoami)-pubkey.asc\ny\n" | \
     /usr/local/bin/mig-console -q || fail
 
 echo -e "\n---- Creating agent configuration\n"


### PR DESCRIPTION
Adds support for using a standard API key where required to access the MIG API. This essentially adds an alternative to using X-PGPAUTHORIZATION which may be more easily utilized for integration of external applications with the API.

Note: this changes nothing related to action signing and interrogating agents, and is solely utilized for simplified access to functions the API provides itself.