### PR TITLE
[minor] Adding option to set agent tags in external config file

### DIFF
--- a/conf/mig-agent-conf.go.inc
+++ b/conf/mig-agent-conf.go.inc
@@ -11,11 +11,9 @@ import (
 )
 
 // some tags that are useful to differentiate agents. You can add whatever
-// you want in this struct, it will be sent by the agent in each heartbeat
-var TAGS = struct {
-	Operator string `json:"operator"`
-}{
-	"MyFavoriteAdminTeam",
+// you want in this map, it will be sent by the agent in each heartbeat
+var TAGS = map[string]string {
+    "operator": "MyFavoriteAdminTeam",
 }
 
 // restart the agent on failures, don't let it die

--- a/conf/mig-agent.cfg.inc
+++ b/conf/mig-agent.cfg.inc
@@ -54,6 +54,11 @@
     ; if true, only the investigator's public key is verified on actions and not ACLs.
     onlyVerifyPubKey = false
 
+    ; Tag the instance with attributes to filter investigation scope
+    tags = "operator:Ops_Emea"
+    tags = "role:web"
+
+
 [stats]
     ; number of previous actions the agent should keep a summary for. the summary can
     ; be viewed over the agent stat socket. 0 to disable.

--- a/conf/mig-loader-conf.go.inc
+++ b/conf/mig-loader-conf.go.inc
@@ -6,11 +6,9 @@
 package main
 
 // some tags that are useful to differentiate agents. You can add whatever
-// you want in this struct, it will be sent by the agent in each heartbeat
-var TAGS = struct {
-	Operator string `json:"operator"`
-}{
-	"MyFavoriteAdminTeam",
+// you want in this map, it will be sent by the agent in each heartbeat
+var TAGS = map[string]string {
+    "operator": "MyFavoriteAdminTeam",
 }
 
 // attempt to discover the public IP of the endpoint by querying the api

--- a/mig-agent/configuration.go
+++ b/mig-agent/configuration.go
@@ -11,11 +11,9 @@ import (
 )
 
 // some tags that are useful to differentiate agents. You can add whatever
-// you want in this struct, it will be sent by the agent in each heartbeat
-var TAGS = struct {
-	Operator string `json:"operator"`
-}{
-	"MyFavoriteAdminTeam",
+// you want in this map, it will be sent by the agent in each heartbeat
+var TAGS = map[string]string {
+    "operator": "MyFavoriteAdminTeam",
 }
 
 // restart the agent on failures, don't let it die

--- a/mig-loader/configuration.go
+++ b/mig-loader/configuration.go
@@ -7,10 +7,8 @@ package main
 
 // some tags that are useful to differentiate agents. You can add whatever
 // you want in this struct, it will be sent by the agent in each heartbeat
-var TAGS = struct {
-	Operator string `json:"operator"`
-}{
-	"MyFavoriteAdminTeam",
+var TAGS = map[string]string {
+    "operator": "MyFavoriteAdminTeam",
 }
 
 // attempt to discover the public IP of the endpoint by querying the api

--- a/tools/standalone_install.sh
+++ b/tools/standalone_install.sh
@@ -315,10 +315,8 @@ import(
     "mig.ninja/mig"
     "time"
 )
-var TAGS = struct {
-    Operator string \`json:"operator"\`
-}{
-    "MIGDemo",
+var TAGS = map[string]string {
+    "operator": "MIGDemo",
 }
 var ISIMMORTAL bool = false
 var MUSTINSTALLSERVICE bool = true


### PR DESCRIPTION
Apologies in advance, my go experience is limited at this point so any feedback is constructive!

Currently tags can only be set in the build of the agent binary. Portions of the agents configuration can be set in an external file, so I just added the ability to set tags in that file. The tags are in essence configured as a list of key value pairs separated by colon. At init the tags are parsed and set. Tags set externally are merged with the `TAGS` set in the agent and can be accessed using the new method, `GetTags()`

Tags can be set in this fashion.

```
[agent]
    ; Tag the instance with attributes to filter investigation scope
    tags = "operator:Ops_Emea"
    tags = "role:web"
```