### PR TITLE
Fix bug in Windows logging, add check option to loader

### DIFF
--- a/logging_windows.go
+++ b/logging_windows.go
@@ -154,6 +154,10 @@ func (r *rotateLogWriter) initAndCheck() (err error) {
 	}
 	// Rotate the log and reinitialize it
 	// If the old file already exists remove it
+	//
+	// On Windows, close the existing logging file descriptor first before we
+	// attempt to rename the file.
+	r.fd.Close()
 	rotatefile := r.filename + ".1"
 	_, err = os.Stat(rotatefile)
 	if err == nil || !os.IsNotExist(err) {
@@ -167,8 +171,7 @@ func (r *rotateLogWriter) initAndCheck() (err error) {
 	if err != nil {
 		panic(err)
 	}
-	// Close existing descriptor and reinitialize
-	r.fd.Close()
+	// Reinitialize
 	r.fd, err = os.OpenFile(r.filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0640)
 	if err != nil {
 		panic(err)

--- a/mig-loader/loader.go
+++ b/mig-loader/loader.go
@@ -538,10 +538,12 @@ func main() {
 	var (
 		initialMode bool
 		runService  bool
+		checkOnly   bool
 		err         error
 	)
 	runtime.GOMAXPROCS(1)
 
+	flag.BoolVar(&checkOnly, "c", false, "only check if agent is running")
 	flag.BoolVar(&initialMode, "i", false, "initialization mode")
 	flag.BoolVar(&runService, "s", false, "persistent service mode")
 	flag.Parse()
@@ -578,6 +580,19 @@ func main() {
 			logError("%v", err)
 			doExit(1)
 		}
+	} else if checkOnly {
+		err = agentRunning()
+		if err != nil {
+			logInfo("agent does not appear to be running, trying to start")
+			err = runTriggers()
+			if err != nil {
+				logError("%v", err)
+				doExit(1)
+			}
+		} else {
+			logInfo("agent looks like it is running")
+		}
+		doExit(0)
 	}
 
 	// Get our current status from the file system.


### PR DESCRIPTION
Resolves an issue with Windows logging where rotation fails on this platform due to the file being open when we attempt to rename it.

This also adds the `-c` flag to mig-loader, which instructs the loader to just check if the agent is running and not to do a full manifest compare. This is used in the loader Windows service to periodically check the status of the agent.