### PR TITLE
[minor] findPublicIP: reduce Dial timeout to 5 seconds

### DIFF
--- a/mig-agent/agentcontext/env.go
+++ b/mig-agent/agentcontext/env.go
@@ -41,7 +41,7 @@ func findPublicIP(orig_ctx AgentContext, hints AgentContextHints) (ctx AgentCont
 	ctx = orig_ctx
 
 	tr := &http.Transport{
-		Dial: (&net.Dialer{Timeout: 10 * time.Second}).Dial,
+		Dial: (&net.Dialer{Timeout: 5 * time.Second}).Dial,
 	}
 	client := &http.Client{Transport: tr}
 	var resp *http.Response


### PR DESCRIPTION
Reduce the dial timeout to 5 seconds time 10. This operation should
normally occur quickly, but in some cases (e.g., an unreachable proxy in
use) the request will stall. This ensures we wait a maximum of 5 seconds
before trying another option.

This also aligns the timeout with the dial timeout for AMQP connections.