### PR TITLE
update CONTRIBUTING.md, remove requirement to tag commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,15 +15,12 @@ Take a look at the list of [issues labelled "up for grabs"](https://github.com/m
 
 ## Coding guidelines
 
-* Commits must be prefixed with one of the following tag:
-    - `[doc]` for commits that update documentation
-    - `[minor]`, `[medium]`, `[major]` for regular commits, pick the level that
-      represents the importance of your commit the best.
-    - `[(level)/bug]` for commits that fix a bug
+* Commits must be descriptive of the change that is being made to the
+  source code.
 
 * If your commit is linked to a github issue, please add a reference
   to it in the commit message.
-  ex: `[minor] fix bad counter on agent stats, fixes #125123`
+  ex: `fix bad counter on agent stats, fixes #125123`
 
 * Pull requests must represent the final state of your commit. If you spent two
   weeks working on code, please only submit the commits that represent the


### PR DESCRIPTION
This removes any sort of requirement to prefix commit messages from the
contributing guidelines. This was originally intended to provide a means
to identify large changes/feature additions in the revision history.

Removing this to make it easier for contributors to submit patches
without requiring history revision.