### PR TITLE
Fixes a few issues in how Init failures are handled

### DIFF
--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -422,9 +422,9 @@ func runAgent(runOpt runtimeOptions) (err error) {
 			ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("Init failed: '%v'", err)}.Err()
 		}
 		if runOpt.foreground {
-			// if in foreground mode, don't retry, just panic
+			// if in foreground mode, don't retry, just exit
 			time.Sleep(1 * time.Second)
-			panic(err)
+			os.Exit(1)
 		}
 		if ctx.Agent.Respawn {
 			// if init fails, sleep for one minute and try again. forever.

--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -355,7 +355,7 @@ func runAgentCheckin(runOpt runtimeOptions) (err error) {
 	ctx, err = Init(runOpt.foreground, runOpt.upgrading)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Init failed: '%v'", err)
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	ctx.Agent.Mode = "checkin"

--- a/mig-agent/context.go
+++ b/mig-agent/context.go
@@ -120,10 +120,10 @@ func (c *Context) updateVolatileFromAgentContext(actx agentcontext.AgentContext)
 func Init(foreground, upgrade bool) (ctx Context, err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = fmt.Errorf("initAgent() -> %v", e)
+			err = fmt.Errorf("Init() -> %v", e)
 		}
 		if ctx.Channels.Log != nil {
-			ctx.Channels.Log <- mig.Log{Desc: "leaving initAgent()"}.Debug()
+			ctx.Channels.Log <- mig.Log{Desc: "leaving Init()"}.Debug()
 		}
 	}()
 	// Pick up a lock on Context Agent field as we will be updating or reading it here and in


### PR DESCRIPTION
In checkin mode, make sure a non-zero exit status is returned if the agent fails to start up.

This also changes the way failures from Init are handled in foreground mode, so the agent exits cleanly with an error message rather than a panic.