### PR TITLE
Doc/fix rst typo

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -810,9 +810,11 @@ and will look after upgrading the agent automatically if you want to publish new
 agent updates. The upgrades can be controlled by a MIG administrator through the
 MIG API and console tools.
 
-For information on the loader, see `MIG LOADER`_ documentation. If you wish to
-use mig-loader, read the `MIG LOADER`_ documentation to understand how the rest
+For information on the loader, see `mig-loader`_ documentation. If you wish to
+use mig-loader, read the `mig-loader`_ documentation to understand how the rest
 of this guide fits into configuration with loader based deployment.
+
+.. _`mig-loader`: loader.rst
 
 Agent Configuration
 -------------------

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -232,7 +232,7 @@ When validation fails, an error with a descriptive validation failure must be
 returned to the caller.
 
 A good example of validating parameters can be found in the ``file`` module at
-https://github.com/mozilla/mig/blob/master/src/mig/modules/file/file.go
+https://github.com/mozilla/mig/blob/master/modules/file/file.go
 
 Results
 -------


### PR DESCRIPTION
Fix different RST typo inside doc dir:

* link between configuration.rst and loader.rst
* external link to file.go from modules.rst