### PR TITLE
abstract Client http.Client with an interface

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
+
+package client /* import "mig.ninja/mig/client" */
+
+import (
+	"net/http"
+
+	"github.com/jvehent/cljs"
+	"mig.ninja/mig"
+)
+
+func init() {
+	GetClientFunction = NewTestClient
+}
+
+type TestClient struct {
+	Conf Configuration
+}
+
+func NewTestClient(conf Configuration, version string) (ret Client, err error) {
+	cli := &TestClient{}
+	return cli, nil
+}
+
+func (cli TestClient) CompressAction(act mig.Action) (ret mig.Action, err error) {
+	return
+}
+
+func (cli TestClient) DisableDebug() {
+}
+
+func (cli TestClient) Do(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (cli TestClient) EnableDebug() {
+}
+
+func (cli TestClient) EvaluateAgentTarget(target string) ([]mig.Agent, error) {
+	return nil, nil
+}
+
+func (cli TestClient) FetchActionResults(act mig.Action) ([]mig.Command, error) {
+	return nil, nil
+}
+
+func (cli TestClient) FollowAction(act mig.Action, total int) error {
+	return nil
+}
+
+func (cli TestClient) GetAction(aid float64) (act mig.Action, links []cljs.Link, err error) {
+	return
+}
+
+func (cli TestClient) GetAgent(agtid float64) (ret mig.Agent, err error) {
+	return
+}
+
+func (cli TestClient) GetAPIResource(target string) (*cljs.Resource, error) {
+	return nil, nil
+}
+
+func (cli TestClient) GetConfiguration() Configuration {
+	return cli.Conf
+}
+
+func (cli TestClient) GetCommand(cid float64) (ret mig.Command, err error) {
+	return
+}
+
+func (cli TestClient) GetInvestigator(iid float64) (ret mig.Investigator, err error) {
+	return
+}
+
+func (cli TestClient) GetLoaderEntry(lid float64) (ret mig.LoaderEntry, err error) {
+	return
+}
+
+func (cli TestClient) GetManifestLoaders(mid float64) ([]mig.LoaderEntry, error) {
+	return nil, nil
+}
+
+func (cli TestClient) GetManifestRecord(mid float64) (ret mig.ManifestRecord, err error) {
+	return
+}
+
+func (cli TestClient) LoaderEntryExpect(le mig.LoaderEntry, expect string) error {
+	return nil
+}
+
+func (cli TestClient) LoaderEntryKey(le mig.LoaderEntry) (ret mig.LoaderEntry, err error) {
+	return
+}
+
+func (cli TestClient) LoaderEntryStatus(le mig.LoaderEntry, status bool) error {
+	return nil
+}
+
+func (cli TestClient) ManifestRecordStatus(mr mig.ManifestRecord, status string) error {
+	return nil
+}
+
+func (cli TestClient) PostAction(act mig.Action) (ret mig.Action, err error) {
+	return
+}
+
+func (cli TestClient) PostInvestigator(name string, pubkey []byte, perms mig.InvestigatorPerms) (inv mig.Investigator, err error) {
+	return
+}
+
+func (cli TestClient) PostInvestigatorAPIKeyStatus(iid float64, status string) (ret mig.Investigator, err error) {
+	return
+}
+
+func (cli TestClient) PostInvestigatorPerms(iid float64, perms mig.InvestigatorPerms) error {
+	return nil
+}
+
+func (cli TestClient) PostInvestigatorStatus(iid float64, status string) error {
+	return nil
+}
+
+func (cli TestClient) PostManifestSignature(mr mig.ManifestRecord, sig string) error {
+	return nil
+}
+
+func (cli TestClient) PostNewLoader(le mig.LoaderEntry) (ret mig.LoaderEntry, err error) {
+	return
+}
+
+func (cli TestClient) PostNewManifest(mr mig.ManifestRecord) error {
+	return nil
+}
+
+func (cli TestClient) PrintActionResults(act mig.Action, show string, render string) error {
+	return nil
+}
+
+func (cli TestClient) ResolveTargetMacro(target string) string {
+	return ""
+}
+
+func (cli TestClient) SignAction(act mig.Action) (ret mig.Action, err error) {
+	return
+}
+
+func (cli TestClient) SignManifest(mr mig.ManifestRecord) (ret string, err error) {
+	return
+}

--- a/client/mig-console/console.go
+++ b/client/mig-console/console.go
@@ -87,7 +87,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Fprintf(out, "\nConnected to %s. Exit with \x1b[32;1mctrl+d\x1b[0m. Type \x1b[32;1mhelp\x1b[0m for help.\n", cli.Conf.API.URL)
+	fmt.Fprintf(out, "\nConnected to %s. Exit with \x1b[32;1mctrl+d\x1b[0m. Type \x1b[32;1mhelp\x1b[0m for help.\n", cli.GetConfiguration().API.URL)
 	for {
 		// completion
 		var symbols = []string{"action", "agent", "create", "command", "help", "history",
@@ -227,8 +227,9 @@ status			display platform status: connected agents, latest actions, ...
 				log.Println(err)
 			}
 		case "showcfg":
+			conf := cli.GetConfiguration()
 			fmt.Printf("homedir = %s\n[api]\n    url = %s\n[gpg]\n    home = %s\n    keyid = %s\n",
-				cli.Conf.API.URL, cli.Conf.Homedir, cli.Conf.GPG.Home, cli.Conf.GPG.KeyID)
+				conf.API.URL, conf.Homedir, conf.GPG.Home, conf.GPG.KeyID)
 		case "status":
 			err = printStatus(cli)
 			if err != nil {

--- a/client/mig-console/investigator.go
+++ b/client/mig-console/investigator.go
@@ -349,7 +349,7 @@ func investigatorCreator(cli client.Client) (err error) {
 		re := regexp.MustCompile(`^0x[ABCDEF0-9]{8,64}$`)
 		if re.MatchString(input) {
 			var keyserver string
-			if cli.Conf.GPG.Keyserver == "" {
+			if cli.GetConfiguration().GPG.Keyserver == "" {
 				keyserver = "http://gpg.mozilla.org"
 			}
 			fmt.Println("retrieving public key from", keyserver)


### PR DESCRIPTION
Introduces a new Client interface type which is used to interact with
the MIG API. The main intent of this interface is to allow substitution
of the Client type with other implementations (e.g., a Client type
suitable for unit testing).

The original Client becomes MIGClient, and satisfies the Client
interface.

A test file has been included that adds a new TestClient type which also
satisfies Client, and can be extended for internal tests.

Also, the existing http.Client member of the MIG client type has been
replaced with a requestor interface. This is intended to permit the
default client http.Client and transport configuration to be replaced if
custom options are desired.