### PR TITLE
file: don't skip adding path separator if directory entry is a symlink

### DIFF
--- a/modules/file/file.go
+++ b/modules/file/file.go
@@ -840,9 +840,8 @@ func (r *run) pathWalk(path string, roots []string) (traversed []string, err err
 		// loop over the content of the directory
 		for _, dirEntry := range dirContent {
 			entryAbsPath := path
-			// append path separator if missing & not a symlink
-			// (usefull for first path)
-			if entryAbsPath[len(entryAbsPath)-1] != os.PathSeparator && (dirEntry.Mode()&os.ModeSymlink != os.ModeSymlink) {
+			// append path separator if missing
+			if entryAbsPath[len(entryAbsPath)-1] != os.PathSeparator {
 				entryAbsPath += string(os.PathSeparator)
 			}
 			entryAbsPath += dirEntry.Name()


### PR DESCRIPTION
If a file symlink existed in the root of a search path (e.g., /tmp was
being searched and /tmp/file was a symlink) path separators were not
being added correctly, resulting in no separator between the directory
path and the file name.

This caused subsequent checks (e.g., trying to follow and open the
symlink for content inspection) to fail, resulting in errors being
included in the module error log.