### PR TITLE
file: fix bug with maxerror handling when matchall was false

### DIFF
--- a/modules/file/file.go
+++ b/modules/file/file.go
@@ -1741,8 +1741,8 @@ func (r *run) buildResults(t0 time.Time) (resStr string, err error) {
 				// store the value of maxerrors if greater than the one
 				// we already have, we'll need it further down to return
 				// the right number of walking errors
-				if int(mf.Search.Options.MaxErrors) > maxerrors {
-					maxerrors = int(mf.Search.Options.MaxErrors)
+				if int(search.Options.MaxErrors) > maxerrors {
+					maxerrors = int(search.Options.MaxErrors)
 				}
 				mf.Search.Options.MaxDepth = 0
 				mf.Search.Options.MaxErrors = 0


### PR DESCRIPTION
Don't use MaxErrors from the matched file var, as the Search field has
not been set here. Use MaxErrors from the parent Search type we are
currently inspecting checks for instead.