### PR TITLE
Fixes for tests and build on Darwin

### DIFF
--- a/vendor/github.com/mozilla/masche/listlibs/listlibs_darwin.go
+++ b/vendor/github.com/mozilla/masche/listlibs/listlibs_darwin.go
@@ -35,7 +35,7 @@ func listLoadedLibraries(p process.Process) (libraries []string, softerrors []er
 			Len:  int(*count),
 			Cap:  int(*count)}))
 
-	processName, harderror, softs := p.Name()
+	processName, softs, harderror := p.Name()
 	if harderror != nil {
 		return
 	}

--- a/vendor/github.com/mozilla/masche/memaccess/memaccess_c_wrapper.go
+++ b/vendor/github.com/mozilla/masche/memaccess/memaccess_c_wrapper.go
@@ -26,7 +26,7 @@ func nextReadableMemoryRegion(p process.Process, address uintptr) (region Memory
 	C.response_free(response)
 
 	if harderror != nil || isAvailable == false {
-		return NoRegionAvailable, harderror, softerrors
+		return NoRegionAvailable, softerrors, harderror
 	}
 
 	return MemoryRegion{uintptr(cRegion.start_address), uint(cRegion.length)}, softerrors, harderror

--- a/vendor/github.com/mozilla/masche/process/process_c_wrapper.go
+++ b/vendor/github.com/mozilla/masche/process/process_c_wrapper.go
@@ -33,7 +33,7 @@ func openFromPid(pid uint) (p Process, softerrors []error, harderror error) {
 	var result process
 
 	resp := C.open_process_handle(C.pid_tt(pid), &result.hndl)
-	harderror, softerrors = cresponse.GetResponsesErrors(unsafe.Pointer(resp))
+	softerrors, harderror = cresponse.GetResponsesErrors(unsafe.Pointer(resp))
 	C.response_free(resp)
 
 	if harderror == nil {


### PR DESCRIPTION
Update the file test so it resolves the symbolic link path used for the test base directory, since on Darwin the path returned by TempDir is a symlink. This ensures the correct path is used when comparing the results of the various tests.

Also update masche library, which contains fixes preventing build on Darwin with memory module support.