### PR TITLE
doc: include a reference to modulepack in the config guide

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -794,6 +794,11 @@ or ``go install``.
 
         $ go install -tags 'modnodefaults modmemory' mig.ninja/mig/mig-agent
 
+For details on the various tags that can be specified, see the source of the
+`modulepack package`_.
+
+.. _`modulepack package`: ../modulepack
+
 Install the agent configuration file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add a reference to the modulepack package in the configuration guide
that can help determine what tags to use to get certain module
configurations in the agent and clients.