### PR TITLE
agent: use path.Join instead of string concat to construct agtid/ok

### DIFF
--- a/mig-agent/agent.go
+++ b/mig-agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
 	"strings"
 	"sync"
@@ -931,11 +932,11 @@ func heartbeat(ctx *Context) (err error) {
 		ctx.Channels.Log <- mig.Log{Desc: desc}.Debug()
 		publish(ctx, mig.Mq_Ex_ToSchedulers, mig.Mq_Q_Heartbeat, body)
 		// update the local heartbeat file
-		err = ioutil.WriteFile(ctx.Agent.RunDir+"mig-agent.ok", []byte(time.Now().String()), 0644)
+		err = ioutil.WriteFile(path.Join(ctx.Agent.RunDir, "mig-agent.ok"), []byte(time.Now().String()), 0644)
 		if err != nil {
 			ctx.Channels.Log <- mig.Log{Desc: "Failed to write mig-agent.ok to disk"}.Err()
 		}
-		os.Chmod(ctx.Agent.RunDir+"mig-agent.ok", 0644)
+		os.Chmod(path.Join(ctx.Agent.RunDir, "mig-agent.ok"), 0644)
 		time.Sleep(ctx.Sleeper)
 	}
 	return

--- a/mig-agent/agentcontext/agent-context.go
+++ b/mig-agent/agentcontext/agent-context.go
@@ -18,6 +18,7 @@ import (
 	mrand "math/rand"
 	"mig.ninja/mig"
 	"os"
+	"path"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -222,7 +223,7 @@ func initAgentID(orig_ctx AgentContext) (ctx AgentContext, err error) {
 		logChan <- mig.Log{Desc: "leaving initAgentID()"}.Debug()
 	}()
 	os.Chmod(ctx.RunDir, 0755)
-	idFile := ctx.RunDir + ".migagtid"
+	idFile := path.Join(ctx.RunDir, ".migagtid")
 	id, err := ioutil.ReadFile(idFile)
 	if err != nil {
 		logChan <- mig.Log{Desc: fmt.Sprintf("unable to read agent id from '%s': %v", idFile, err)}.Debug()
@@ -295,7 +296,7 @@ func createIDFile(ctx AgentContext) (id []byte, err error) {
 		}
 	}
 
-	idFile := ctx.RunDir + ".migagtid"
+	idFile := path.Join(ctx.RunDir, ".migagtid")
 
 	// something exists at the location of the id file, just plain remove it
 	_ = os.Remove(idFile)


### PR DESCRIPTION
Fixes a bug where string concatenation was being used construct the path to the agent ID file, which could cause problems if the path did not explicitly end in a directory separator (e.g., /), instead use the standard path join function