### PR TITLE
Pass trimmed input line to commands

### DIFF
--- a/client/mig-console/console.go
+++ b/client/mig-console/console.go
@@ -114,7 +114,8 @@ func main() {
 			fmt.Println("error: ", err)
 			break
 		}
-		orders := strings.Split(strings.TrimSpace(input), " ")
+		input = strings.TrimSpace(input)
+		orders := strings.Split(input, " ")
 		switch orders[0] {
 		case "action":
 			if len(orders) == 2 {


### PR DESCRIPTION
The space was trimmed and split in console.go, but the original `input` was passed to the specified command.

The command then splits the input again, but doesn't necessarily trim trailing spaces that are then counted as empty arguments. This breaks the check for required argument when using tab completion.