### PR TITLE
Remove CNAME file in prep for Cloudfront distribution

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-mig.mozilla.org


### PR DESCRIPTION
This PR removes the CNAME file reference from the mig github page.  The intent of this change is to frontend mig.mozilla.org with a CloudFront Distribution with the github page set as an origin.  In such a model, the CNAME claim in github is no longer relevant (in fact it's a hinderence) because calls from CloudFront will actually be pulling this content over mozilla.github.io/mig rather than mig.mozilla.org and CloudFront will be the frontend as mig.mozilla.org.

This is associated with work in https://bugzilla.mozilla.org/show_bug.cgi?id=1438966 and merging it will need to be syncronized with DNS re-pointing from github to the cloudfront distribution in Route53.