### PR TITLE
Fixed format string errors that were blocking make test

### DIFF
--- a/acl_test.go
+++ b/acl_test.go
@@ -148,7 +148,7 @@ func TestValidACLMultipleSignersOneValid(t *testing.T) {
 	err = verifyPermission("file", acl, []string{"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 		"DDDDDDDDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"})
 	if err == nil {
-		t.Fatalf("verifyPermission should have failed", err)
+		t.Fatalf("verifyPermission should have failed. Error: %v", err)
 	}
 }
 

--- a/action.go
+++ b/action.go
@@ -332,8 +332,16 @@ func (a Action) String() (str string, err error) {
 	if err != nil {
 		return
 	}
-	str += fmt.Sprintf("name=%s;target=%s;validfrom=%d;expireafter=%d;operations=%s;",
-		a.Name, a.Target, a.ValidFrom.UTC().Unix(), a.ExpireAfter.UTC().Unix(), args)
+
+	// Before this addition, the code below (`str += fmt.Sprintf(...)`) was formatting
+	// `a.ExpireAfter.UTC().Unix()` as a string, using `%s`.  In version 1.10 of the Go
+	// compiler, this is an error.  However in older versions, the numeric value would
+	// be converted to a string and wrapped with the formatting information you see
+	// being added here.
+	expire := fmt.Sprintf("%%!s(int64=%d)", a.ExpireAfter.UTC().Unix())
+
+	str += fmt.Sprintf("name=%s;target=%s;validfrom=%d;expireafter=%s;operations=%s;",
+		a.Name, a.Target, a.ValidFrom.UTC().Unix(), expire, args)
 	return
 }
 

--- a/action.go
+++ b/action.go
@@ -332,7 +332,7 @@ func (a Action) String() (str string, err error) {
 	if err != nil {
 		return
 	}
-	str += fmt.Sprintf("name=%s;target=%s;validfrom=%d;expireafter=%s;operations=%s;",
+	str += fmt.Sprintf("name=%s;target=%s;validfrom=%d;expireafter=%d;operations=%s;",
 		a.Name, a.Target, a.ValidFrom.UTC().Unix(), a.ExpireAfter.UTC().Unix(), args)
 	return
 }

--- a/action_test.go
+++ b/action_test.go
@@ -374,7 +374,7 @@ func TestVerifyBadSig(t *testing.T) {
 	keyring.Seek(0, 0)
 	err = a.VerifyACL(acl, keyring, false)
 	if err == nil {
-		t.Fatalf("VerifyACL should have failed", err)
+		t.Fatalf("VerifyACL should have failed. Error: %v", err)
 	}
 
 	// Try this again, but this time add the invalid signer to the keyring and invalidate the entry

--- a/client/mig-console/action_launcher.go
+++ b/client/mig-console/action_launcher.go
@@ -357,8 +357,7 @@ times			show the various timestamps of the action
 				fmt.Println(`Invalid times. Expects settimes <start> <stop.)
 examples:
 settimes 2014-06-30T12:00:00.0Z 2014-06-30T14:00:00.0Z
-settimes now +60m
-`)
+settimes now +60m`)
 				break
 			}
 			if orders[1] == "now" {
@@ -366,7 +365,7 @@ settimes now +60m
 				a.ValidFrom = time.Now().Add(-60 * time.Second).UTC()
 				period, err := time.ParseDuration(orders[2])
 				if err != nil {
-					fmt.Println("Failed to parse duration '%s': %v", orders[2], err)
+					fmt.Printf("Failed to parse duration '%s': %v\n", orders[2], err)
 					break
 				}
 				a.ExpireAfter = a.ValidFrom.Add(period)
@@ -374,12 +373,12 @@ settimes now +60m
 			} else {
 				a.ValidFrom, err = time.Parse("2014-01-01T00:00:00.0Z", orders[1])
 				if err != nil {
-					fmt.Println("Failed to parse time '%s': %v", orders[1], err)
+					fmt.Printf("Failed to parse time '%s': %v\n", orders[1], err)
 					break
 				}
 				a.ExpireAfter, err = time.Parse("2014-01-01T00:00:00.0Z", orders[2])
 				if err != nil {
-					fmt.Println("Failed to parse time '%s': %v", orders[2], err)
+					fmt.Printf("Failed to parse time '%s': %v\n", orders[2], err)
 					break
 				}
 			}

--- a/client/mig-console/investigator.go
+++ b/client/mig-console/investigator.go
@@ -320,10 +320,10 @@ func investigatorCreator(cli client.Client) (err error) {
 	}
 	switch strings.ToLower(respv) {
 	case "yes":
-		fmt.Println("Investigator will have manifest management permissions\n")
+		fmt.Println("Investigator will have manifest management permissions")
 		pset.ManifestSet()
 	case "no":
-		fmt.Println("Investigator will not have manifest management permissions\n")
+		fmt.Println("Investigator will not have manifest management permissions")
 	default:
 		panic("must specify yes or no")
 	}

--- a/client/mig-console/investigator.go
+++ b/client/mig-console/investigator.go
@@ -320,10 +320,10 @@ func investigatorCreator(cli client.Client) (err error) {
 	}
 	switch strings.ToLower(respv) {
 	case "yes":
-		fmt.Println("Investigator will have manifest management permissions")
+		fmt.Printf("Investigator will have manifest management permissions\n\n")
 		pset.ManifestSet()
 	case "no":
-		fmt.Println("Investigator will not have manifest management permissions")
+		fmt.Printf("Investigator will not have manifest management permissions\n\n")
 	default:
 		panic("must specify yes or no")
 	}

--- a/client/mig-console/search.go
+++ b/client/mig-console/search.go
@@ -97,7 +97,7 @@ The following search parameters are available, per search type:
         - agentname=<str>       search loaders for associated agent names
 
 All searches accept the 'limit=<num>' parameter to limits the number of results returned by a search, defaults to 100
-Parameters that accept a <str> can use wildcards * and % (ex: name=jul%veh% ).
+Parameters that accept a <str> can use wildcards * and %% (ex: name=jul%%veh%% ).
 No spaces are permitted within parameters. Spaces are used to separate search parameters.
 `)
 		return nil

--- a/mig-api/action_endpoints.go
+++ b/mig-api/action_endpoints.go
@@ -46,7 +46,7 @@ func createAction(respWriter http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		panic(err)
 	}
-	ctx.Channels.Log <- mig.Log{OpID: opid, Desc: fmt.Sprintf("Received action for creation '%s'", action)}.Debug()
+	ctx.Channels.Log <- mig.Log{OpID: opid, Desc: fmt.Sprintf("Received action for creation '%v'", action)}.Debug()
 
 	// Init action fields
 	action.ID = mig.GenID()

--- a/mig-scheduler/pgp.go
+++ b/mig-scheduler/pgp.go
@@ -141,6 +141,6 @@ func makeSchedulerInvestigator(orig_ctx Context) (inv mig.Investigator, err erro
 	if err != nil {
 		panic(err)
 	}
-	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("created migscheduler identity with ID %d and key ID %s", iid, inv.PGPFingerprint)}
+	ctx.Channels.Log <- mig.Log{Desc: fmt.Sprintf("created migscheduler identity with ID %f and key ID %s", iid, inv.PGPFingerprint)}
 	return
 }

--- a/modules/agentdestroy/agentdestroy.go
+++ b/modules/agentdestroy/agentdestroy.go
@@ -56,7 +56,7 @@ type results struct {
 
 func (r *run) ValidateParameters() (err error) {
 	if r.Parameters.PID < 2 || r.Parameters.PID > 65535 {
-		return fmt.Errorf("PID '%s' is not in the range [2:65535]", r.Parameters.PID)
+		return fmt.Errorf("PID '%d' is not in the range [2:65535]", r.Parameters.PID)
 	}
 	if r.Parameters.Version == "" {
 		return fmt.Errorf("parameter 'version' is empty. Expecting version.")

--- a/modules/file/file_test.go
+++ b/modules/file/file_test.go
@@ -92,13 +92,13 @@ func TestValidateParameters(t *testing.T) {
 	r.Parameters = *newParameters()
 	err := r.ValidateParameters()
 	if err != nil {
-		t.Fatal("ValidateParameters: %v", err)
+		t.Fatalf("ValidateParameters: %v", err)
 	}
 
 	r.Parameters.Searches["s1"] = &s
 	err = r.ValidateParameters()
 	if err == nil {
-		t.Fatalf("parameters with empty search path should not validate", err)
+		t.Fatalf("parameters with empty search path should not validate. Error: %v", err)
 	}
 
 	s.Paths = append(s.Paths, "/testing")

--- a/modules/file/paramscreator.go
+++ b/modules/file/paramscreator.go
@@ -139,7 +139,7 @@ func (r *run) ParamsCreator() (interface{}, error) {
 				continue
 			}
 			if _, exist := p.Searches[label]; exist {
-				fmt.Printf("A search labelled", label, "already exist. Override it?\n(y/n)> ")
+				fmt.Printf("A search labelled %s already exist. Override it?\n(y/n)> ", label)
 				scanner.Scan()
 				if err := scanner.Err(); err != nil {
 					fmt.Println("Invalid input.")

--- a/modules/memory/params.go
+++ b/modules/memory/params.go
@@ -93,7 +93,7 @@ func (r *run) ParamsCreator() (interface{}, error) {
 				continue
 			}
 			if _, exist := p.Searches[label]; exist {
-				fmt.Printf("A search labelled", label, "already exist. Override it?\n(y/n)> ")
+				fmt.Printf("A search labelled %s already exist. Override it?\n(y/n)> ", label)
 				scanner.Scan()
 				if err := scanner.Err(); err != nil {
 					fmt.Println("Invalid input.")

--- a/modules/ping/paramscreator.go
+++ b/modules/ping/paramscreator.go
@@ -106,7 +106,7 @@ func (r *run) ParamsCreator() (interface{}, error) {
 		case "dp":
 			p.DestinationPort, err = strconv.ParseFloat(splitted[1], 64)
 			if err != nil {
-				fmt.Println("invalid destination port: %v", err)
+				fmt.Printf("invalid destination port: %v\n", err)
 				continue
 			}
 		case "p":
@@ -114,13 +114,13 @@ func (r *run) ParamsCreator() (interface{}, error) {
 		case "c":
 			p.Count, err = strconv.ParseFloat(splitted[1], 64)
 			if err != nil {
-				fmt.Println("invalid count: %v", err)
+				fmt.Printf("invalid count: %v\n", err)
 				continue
 			}
 		case "t":
 			p.Timeout, err = strconv.ParseFloat(splitted[1], 64)
 			if err != nil {
-				fmt.Println("invalid timeout: %v", err)
+				fmt.Printf("invalid timeout: %v\n", err)
 				continue
 			}
 		case "help":

--- a/pgp/verify.go
+++ b/pgp/verify.go
@@ -43,7 +43,7 @@ func Verify(data string, signature string, keyring io.Reader) (valid bool, entit
 		panic(err)
 	}
 
-	entity, err = openpgp.CheckDetachedSignature(ring, srcReader, sigBlock.Body)
+	entity, err = openpgp.CheckArmoredDetachedSignature(ring, srcReader, sigBlock.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/pgp/verify.go
+++ b/pgp/verify.go
@@ -43,7 +43,7 @@ func Verify(data string, signature string, keyring io.Reader) (valid bool, entit
 		panic(err)
 	}
 
-	entity, err = openpgp.CheckArmoredDetachedSignature(ring, srcReader, sigBlock.Body)
+	entity, err = openpgp.CheckDetachedSignature(ring, srcReader, sigBlock.Body)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
As I reported in #437, I was seeing some errors after running `make test` that were causing tests to fail.  These errors are extremely simple format string issues which seem to be being handled more strictly in more recent versions of Go (I'm using 1.10).

I'd like some feedback about how to proceed from where this PR would leave us.  My commit here fixes the format string errors I encountered, however I am now seeing some different errors. These ones appear to be more critical issues relevant to the actual function of MIG.  I would hate to submit a PR that still has errors, but hope we can discuss how to proceed. It may be desirable to use the branch I've created as a pivot around which we'll commit more fixes before merging into `master`.

```
OOS=darwin GOARCH=amd64 GO15VENDOREXPERIMENT=1 go test mig.ninja/mig
--- FAIL: TestVerifyACLValid (0.00s)
	action_test.go:225: VerifySignatures: VerifySignatures() -> openpgp: invalid signature: hash tag doesn't match
--- FAIL: TestVerifyGoodSigBadACL (0.00s)
	action_test.go:297: VerifySignatures: VerifySignatures() -> openpgp: invalid signature: hash tag doesn't match
--- FAIL: TestVerifyBadSig (0.00s)
	action_test.go:394: VerifySignatures: VerifySignatures() -> openpgp: invalid signature: hash tag doesn't match
--- FAIL: TestVerifyMultiOperation (0.00s)
	action_test.go:440: VerifySignatures: VerifySignatures() -> openpgp: invalid signature: hash tag doesn't match
FAIL
FAIL	mig.ninja/mig	0.016s
```