### PR TITLE
Setting up an S3 bucket safely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ script:
   docker logout
 deploy:
   provider: s3
-  access_key_id: 'AKIAJ7VGWUJBJHH4J36A'
+  access_key_id: AKIAIE7AXHXLPYI6OBLQ
   secret_access_key:
-    secure: OEz0Dl1NxIahP2RyOpP3vkl5Thvn2XU5IAeWoYrvGfuLtpdB5Jk+lfW9oeJrbfdCObXbAIdcR/HCUBae8AInbU4R6xCWir2cDhEJ1ZW4ujarhp9QGCgR3H+J1+I1BNeR+ugyIHurgQWVCYVDfLX9SiC4YvhOp6YTuVEVV3wEuLA=
-  bucket: 'mig-agent-releases'
+    secure: U0LhIhoa0GZGj5R2CdagKSrP9qX5HrGMYjZSNnI5LYRM/Y0XuuBRUFajit8KspCcpV/H5RAvKmGE7P8TXFy8D7doh6ZrtCqsMsfEs3VMlik0Mm6ywBybFb4yTOH6GzFAmiWD8n7B8QgxhBktJESkYj+WZ/k8Wxhw6VXeka5mvlw=
+  bucket: mig-agent-releases
   skip_cleanup: true
   region: us-west-2
   local_dir: releases

--- a/aws/releases-cloudtrail-build-user.yml
+++ b/aws/releases-cloudtrail-build-user.yml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Sets up a managed policy for Mig to build and deploy to s3."
+Parameters:
+  S3BucketMigBuilds:
+    Type: "String"
+    Description: "The S3 bucket that your build job will be writing out to. (arn:aws:s3:::mig-agent-releases)"
+Resources:
+  PutBuildstoS3:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: "Managed policy for travis-ci to put builds to s3."
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action: "s3:PutObject"
+            Resource:
+              - !Ref S3BucketMigBuilds
+          -
+            Effect: "Allow"
+            Action: "s3:GetObject"
+            Resource:
+              - !Ref S3BucketMigBuilds
+          -
+            Effect: "Allow"
+            Action: "s3:DeleteObject"
+            Resource:
+              - !Ref S3BucketMigBuilds
+  BuildUser:
+    Type: AWS::IAM::User
+    Properties:
+      ManagedPolicyArns:
+        - !Ref PutBuildstoS3
+      UserName: mig-build-user


### PR DESCRIPTION
This PR includes:

* A CloudTrail stack (courtesy of @andrewkrug) that creates an IAM user specifically for managing the S3 bucket we want to deploy to along with a managed policy for that user
* An updated `.travis.yml` file containing an encrypted secret (and its corresponding ID) owned by the user created by the CloudTrail stack

These changes should make it possible for Travis to push builds to the S3 bucket we have created.