### PR TITLE
Adding support for proxy disabling in gozdef

### DIFF
--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 
 	"github.com/jvehent/gozdef"
-	"gopkg.in/gcfg.v1"
 	"github.com/mozilla/mig"
 	scribemod "github.com/mozilla/mig/modules/scribe"
+	"gopkg.in/gcfg.v1"
 )
 
 // config represents the configuration used by runner-scribe, and is read in on
@@ -28,8 +28,9 @@ import (
 // URL and Source are mandatory settings
 type config struct {
 	MozDef struct {
-		URL    string // URL to post events to MozDef
-		Source string // Source identifier for vulnerability events
+		URL      string // URL to post events to MozDef
+		Source   string // Source identifier for vulnerability events
+		UseProxy bool
 	}
 }
 
@@ -85,7 +86,10 @@ func main() {
 }
 
 func sendVulnerability(item gozdef.VulnEvent) (err error) {
-	ac := gozdef.APIConf{URL: conf.MozDef.URL}
+	ac := gozdef.APIConf{
+		URL:      conf.MozDef.URL,
+		UseProxy: conf.MozDef.UseProxy,
+	}
 	pub, err := gozdef.InitAPI(ac)
 	if err != nil {
 		return

--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jvehent/gozdef"
+	"github.com/mozilla/gozdef"
 	"github.com/mozilla/mig"
 	scribemod "github.com/mozilla/mig/modules/scribe"
 	"gopkg.in/gcfg.v1"

--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -30,7 +30,7 @@ type config struct {
 	MozDef struct {
 		URL      string // URL to post events to MozDef
 		Source   string // Source identifier for vulnerability events
-		UseProxy bool
+		UseProxy bool   // A switch to enable/disable the use of a system-configured proxy
 	}
 }
 


### PR DESCRIPTION
~This PR is dependent on the [oustanding PR for gozdef](https://github.com/jvehent/gozdef/pull/6) to add support to disable the use of a proxy in Gozdef.~

Julien has stated that he no longer intends to maintain gozdef, so I guess I'm inheriting it.  I've forked it to `mozilla/gozdef` and pushed my changes right into master.