### PR TITLE
Always set SourceName to 'mig-runner'

### DIFF
--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -22,14 +22,15 @@ import (
 	"gopkg.in/gcfg.v1"
 )
 
+const sourceName = "runner-scribe"
+
 // config represents the configuration used by runner-scribe, and is read in on
 // initialization
 //
-// URL and Source are mandatory settings
+// URL is mandatory
 type config struct {
 	MozDef struct {
 		URL      string // URL to post events to MozDef
-		Source   string // Source identifier for vulnerability events
 		UseProxy bool   // A switch to enable/disable the use of a system-configured proxy
 	}
 }
@@ -78,6 +79,7 @@ func main() {
 		}
 	}
 	for _, y := range items {
+		y.SourceName = sourceName
 		err = sendVulnerability(y)
 		if err != nil {
 			panic(err)
@@ -167,7 +169,6 @@ func makeVulnerability(initems []gozdef.VulnEvent, cmd mig.Command) (items []goz
 			return items, err
 		}
 		for _, x := range el.Results {
-			itemptr.SourceName = conf.MozDef.Source
 			if !x.MasterResult {
 				// Result was false (vulnerability did not match)
 				continue

--- a/runner-plugins/runner-scribe/main_test.go
+++ b/runner-plugins/runner-scribe/main_test.go
@@ -16,7 +16,6 @@ import (
 
 type mozdef struct {
 	URL      string
-	Source   string
 	UseProxy bool
 }
 
@@ -38,7 +37,6 @@ func TestConfigParsing(t *testing.T) {
 			ExpectedConfig: config{
 				MozDef: mozdef{
 					URL:      "testurl",
-					Source:   "mozdef",
 					UseProxy: true,
 				},
 			},
@@ -55,7 +53,6 @@ func TestConfigParsing(t *testing.T) {
 			ExpectedConfig: config{
 				MozDef: mozdef{
 					URL:      "testurl",
-					Source:   "mozdef",
 					UseProxy: false,
 				},
 			},
@@ -99,13 +96,6 @@ func TestConfigParsing(t *testing.T) {
 				"Expected parsed URL to be %s but it's %s",
 				testCase.ExpectedConfig.MozDef.URL,
 				conf.MozDef.URL)
-		}
-
-		if conf.MozDef.Source != testCase.ExpectedConfig.MozDef.Source {
-			t.Errorf(
-				"Expected parsed Source to be %s but it's %s",
-				testCase.ExpectedConfig.MozDef.Source,
-				conf.MozDef.Source)
 		}
 
 		if conf.MozDef.UseProxy != testCase.ExpectedConfig.MozDef.UseProxy {

--- a/runner-plugins/runner-scribe/main_test.go
+++ b/runner-plugins/runner-scribe/main_test.go
@@ -31,7 +31,6 @@ func TestConfigParsing(t *testing.T) {
 			ConfigString: `
       [mozdef]
       url = "testurl"
-      source = "mozdef"
       useProxy = true
       `,
 			ExpectedConfig: config{
@@ -47,7 +46,6 @@ func TestConfigParsing(t *testing.T) {
 			ConfigString: `
       [mozdef]
       url = "testurl"
-      source = "mozdef"
       useProxy = "notbool"
       `,
 			ExpectedConfig: config{


### PR DESCRIPTION
I couldn't really find a way to write tests for this effectively.  For now I want to get this change merged up to see how it affects mig-runner in production and whether more extensive testing is going to be necessary.  The hope is that this will resolve the issue of runner-scribe exiting with a status code of 1 even when it appears to "work".