### PR TITLE
Query ServiceAPI for Operator & Team

### DIFF
--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -39,15 +39,15 @@ type config struct {
 }
 
 type ServiceApiAsset struct {
-	Id 				string
-	Asset_type 		string
-	Asset_identifier string
-	Team 			string
-	Operator 		string
-	Zone 			string
-	Timestamp 		string
-	Description 	string
-	Score 			int
+	Id 				string `json:"id"`
+	AssetType 		string `json:"asset_type"`
+	AssetIdentifier string `json:"asset_identifier"`
+	Team 			string `json:"team"`
+	Operator 		string `json:"operator"`
+	Zone 			string `json:"zone"`
+	Timestamp 		string `json:"timestamp_utc"`
+	Description 	string `json:"description"`
+	Score 			int `json:"score"`
 }
 
 type ServiceApi struct {
@@ -59,10 +59,10 @@ type ServiceApi struct {
 }
 
 type Auth0Token struct {
-	Access_token	string
-	Scope			string
-	Expires_in		int
-	Token_type		string
+	AccessToken	string `json:"access_token"`
+	Scope			string `json:"scope"`
+	ExpiresIn		int `json:"expires_in"`
+	TokenType		string `json:"token_type"`
 }
 
 const configPath string = "/etc/mig/runner-scribe.conf"
@@ -280,7 +280,7 @@ func GetAuthToken(api ServiceApi) (authToken string) {
 	}
 
 	// serviceAPI expects the Access token in the form of "Bearer <token>"
-	authToken = "Bearer " + body.Access_token
+	authToken = "Bearer " + body.AccessToken
 	return
 }
 
@@ -324,10 +324,10 @@ func GetAssets(m map[string]ServiceApiAsset, api ServiceApi) (err error){
 		return err
 	}
 
-	// build a searchable map, keyed on Asset_identifier (which is usually hostname)
+	// build a searchable map, keyed on AssetIdentifier (which is usually hostname)
 	for _, tempAsset := range allAssets {
 		permanentAsset := tempAsset				//not sure if this is needed
-		m[tempAsset.Asset_identifier] = permanentAsset
+		m[tempAsset.AssetIdentifier] = permanentAsset
 	}
 
 	return

--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -60,14 +60,6 @@ type ServiceApiAsset struct {
 	Score           int    `json:"score"`
 }
 
-type ServiceApi struct {
-	URL          string
-	AuthEndpoint string
-	ClientID     string
-	ClientSecret string
-	Token        string // ephemeral token we generate to connect to ServiceAPI
-}
-
 type Auth0Token struct {
 	AccessToken string        `json:"access_token"`
 	Scope       string        `json:"scope"`

--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -273,7 +273,11 @@ func GetAuthToken(api ServiceApi) (string, error) {
 		}`, api.ClientID, api.ClientSecret, api.URL))
 	
 
-	req, _ := http.NewRequest("POST", api.AuthEndpoint, payload)
+	req, err := http.NewRequest("POST", api.AuthEndpoint, payload)
+	if err != nil {
+		return "", err
+	}
+
 	req.Header.Add("content-type", "application/json")
 
 	res, err := http.DefaultClient.Do(req)
@@ -282,7 +286,10 @@ func GetAuthToken(api ServiceApi) (string, error) {
 	}
 
 	defer res.Body.Close()
-	bodyJSON, _ := ioutil.ReadAll(res.Body)
+	bodyJSON, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
 	
 	// unpack the JSON into an Auth0 token struct
 	var body Auth0Token
@@ -299,7 +306,7 @@ func GetAuthToken(api ServiceApi) (string, error) {
 // query a ServiceAPI instance for the set of all assets
 // load them into a searchable map, keyed to asset hostname
 // the ServiceAPI object must already be loaded with a Bearer token
-func GetAssets(m map[string]ServiceApiAsset, api ServiceApi) (err error){
+func GetAssets(m map[string]ServiceApiAsset, api ServiceApi) (error){
 	
 	// get json array of assets from serviceapi
 	requestURL := api.URL + "api/v1/assets/"
@@ -341,7 +348,7 @@ func GetAssets(m map[string]ServiceApiAsset, api ServiceApi) (err error){
 		m[tempAsset.AssetIdentifier] = tempAsset
 	}
 
-	return
+	return err
 }
 
 // return the operator and team for a given hostname, provided they are in the map of 
@@ -351,7 +358,7 @@ func LookupOperatorTeam(hostname string, m map[string]ServiceApiAsset) (operator
 	operator = m[hostname].Operator
 	team = m[hostname].Team
 
-	return
+	return operator, team
 }
 
 // cvssFromRisk returns a synthesized CVSS score as a string given a risk label

--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -312,10 +313,14 @@ func GetAuthToken() (string, error) {
 // load them into a searchable map, keyed to asset hostname
 // the ServiceAPI object must already be loaded with a Bearer token
 func GetAssets(m map[string]ServiceApiAsset) error {
-
 	// get json array of assets from serviceapi
-	requestURL := conf.ServiceApi.URL + "api/v1/assets/"
-	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	requestURL, err := url.Parse(conf.ServiceApi.URL)
+	if err != nil {
+		return err
+	}
+
+	requestURL.Path = "api/v1/assets/"
+	req, err := http.NewRequest(http.MethodGet, requestURL.String(), nil)	
 	if err != nil {
 		return err
 	}

--- a/runner-plugins/runner-scribe/main.go
+++ b/runner-plugins/runner-scribe/main.go
@@ -87,7 +87,10 @@ func main() {
 		panic(err)
 	}
 
-	// instantiate the searchable map of assets early so we can use it throughout
+	// generate a realtime auth0 auth token
+	conf.api.Token = GetAuthToken(conf.api)
+
+	// load a searchable map of assets from ServiceAPI
 	var serviceApiAssets = make(map[string]ServiceApiAsset)
 	err = GetAssets(serviceApiAssets, conf.api)
 	if err != nil {

--- a/runner-plugins/runner-scribe/main_test.go
+++ b/runner-plugins/runner-scribe/main_test.go
@@ -104,3 +104,44 @@ func TestConfigParsing(t *testing.T) {
 		}
 	}
 }
+
+func TestLookupOperatorTeam(t *testing.T) {
+	var serviceApiAssets = make(map[string]ServiceApiAsset)
+	testCases := [][]string{
+		{ "hostname1", "team1", "operator1" },
+		{ "hostname2", "", "operator2" },
+		{ "hostname3", "team3", "" },
+		{ "hostname4", "", ""},
+	}
+
+	// fill the map with test cases
+	for _, test := range testCases {
+		serviceApiAssets[test[0]] = ServiceApiAsset{AssetIdentifier: test[0], Team: test[1], Operator: test[2]}	
+	}
+
+	// run the test cases
+	for _, test := range testCases {
+		testOperator, testTeam := LookupOperatorTeam(test[0], serviceApiAssets)
+		if testOperator != test[2] || testTeam != test[1] {
+			t.Errorf(
+				"Expected operator to be %v but it is %v. Expected team to be %v but it is %v",
+				test[2],
+				testOperator,
+				test[1],
+				testTeam)
+		}	
+	}
+
+	// test lookup on a nonexistent hostname
+	testOperator, testTeam := LookupOperatorTeam("hostnameDoesNotExist", serviceApiAssets)
+	if testOperator != "" || testTeam != "" {
+		t.Errorf(
+			"Expected operator to be %v but it is %v. Expected team to be %v but it is %v",
+			"",
+			testOperator,
+			"",
+			testTeam)
+	}	
+
+
+}


### PR DESCRIPTION
This restores long-desired functionality to query ServiceAPI for an Operator and Team and then publish those to the vulnerability event being posted to MozDef.

Specifically we:

1. Get an authentication token from Auth0
2. Get all assets that ServiceAPI knows about and store them in a searchable map, keyed to hostname
3. As we encounter a host with vulnerabilities, we lookup operator and team and append them to the vulnerability event. If operator and team are not found in the ServiceAPI data, we set operator based on the config of the agent. Team remains blank.