### PR TITLE
Clean up SystemD agents for smooth re-installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,19 +184,19 @@ rpm-agent: mig-agent
 	make agent-install-script-linux
 	make agent-remove-script-linux
 	fpm \
-    -C tmp \
-    -n mig-agent \
-    --license GPL \
-    --vendor mozilla \
-    --description "Mozilla InvestiGator Agent" \
-		-m "Mozilla <noreply@mozilla.com>" \
-    --url http://mig.mozilla.org \
-    --architecture $(FPMARCH) \
-    -v $(BUILDREV) \
-		--after-remove tmp/agent_remove.sh \
-    --after-install tmp/agent_install.sh \
-		-s dir \
-    -t rpm .
+		-C tmp \
+		--n mig-agent \
+		--license GPL \
+		--vendor mozilla \
+		---description "Mozilla InvestiGator Agent" \
+		--m "Mozilla <noreply@mozilla.com>" \
+		---url http://mig.mozilla.org \
+		---architecture $(FPMARCH) \
+		--v $(BUILDREV) \
+		---after-remove tmp/agent_remove.sh \
+		---after-install tmp/agent_install.sh \
+		--s dir \
+		--t rpm .
 
 deb-agent: mig-agent
 	rm -fr tmp
@@ -206,19 +206,19 @@ deb-agent: mig-agent
 	make agent-install-script-linux
 	make agent-remove-script-linux
 	fpm \
-    -C tmp \
-    -n mig-agent \
-    --license GPL \
-    --vendor mozilla \
+		-C tmp \
+		-n mig-agent \
+		--license GPL \
+		--vendor mozilla \
 		--description "Mozilla InvestiGator Agent\nAgent binary" \
 		-m "Mozilla <noreply@mozilla.com>" \
-    --url http://mig.mozilla.org \
+		--url http://mig.mozilla.org \
 		--architecture $(FPMARCH) \
-    -v $(BUILDREV) \
+		-v $(BUILDREV) \
 		--after-remove tmp/agent_remove.sh \
-    --after-install tmp/agent_install.sh \
+		--after-install tmp/agent_install.sh \
 		-s dir \
-    -t deb .
+		-t deb .
 
 deb-loader: mig-loader
 	rm -fr tmp

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ create-bindir:
 cleanup-agent-systemd:
 	pids=`ps aux | grep -i "systemctl stop mig-agent" | sed -e "s/^[a-z]* *//g" | sed -e "s/ .*//g"`
 	for pid in $pids; do kill -9 $pid; done
-	rm -r /etc/mig
-	rm /etc/systemd/system/mig-agent.service
+	rm -rf /etc/mig
+	rm -f /etc/systemd/system/mig-agent.service
 
 mig-agent: create-bindir
 	@echo building mig-agent for $(OS)/$(ARCH)


### PR DESCRIPTION
This PR is a work in progress. Please do not review or merge it until the WIP status is revoked.

At Mozilla, we have encountered an issue with agents in production wherein updates fail due to hanging `systemctl stop` processes.  In order to be able to cleanly reinstall the agent on a host in such circumstances, we need to kill these hanging processes. We also opt to remove the `/etc/mig` directory and its contents as well as the agent's Unit file.  By doing so, automated processes using tools such as Ansible can more-or-less blindly recreate these resources using the latest versions of them, facilitating a smooth re-install.